### PR TITLE
CN0395: Add support for CN0395 shield

### DIFF
--- a/Arduino Uno R3/examples/CN0395_example/AD7988.cpp
+++ b/Arduino Uno R3/examples/CN0395_example/AD7988.cpp
@@ -1,0 +1,152 @@
+/*!
+ *****************************************************************************
+   @file:    AD7988.c
+   @brief:
+   @version: $Revision$
+   @date:    $Date$
+  -----------------------------------------------------------------------------
+
+  Copyright (c) 2018 Analog Devices, Inc.
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+  - Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+  - Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  - Modified versions of the software must be conspicuously marked as such.
+  - This software is licensed solely and exclusively for use with processors
+    manufactured by or for Analog Devices, Inc.
+  - This software may not be combined or merged with other code in any manner
+    that would cause the software to become subject to terms and conditions
+    which differ from those listed here.
+  - Neither the name of Analog Devices, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+  - The use of this software may or may not infringe the patent rights of one
+    or more patent holders.  This license does not release you from the
+    requirement that you obtain separate licenses from these patent holders
+    to use this software.
+
+  THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. AND CONTRIBUTORS "AS IS" AND ANY
+  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+  TITLE, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+  NO EVENT SHALL ANALOG DEVICES, INC. OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, DAMAGES ARISING OUT OF CLAIMS OF INTELLECTUAL
+  PROPERTY RIGHTS INFRINGEMENT; PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ *****************************************************************************/
+
+/***************************** Include Files **********************************/
+#include <stdio.h>
+#include <math.h>
+
+#include <Arduino.h>
+#include "AD7988.h"
+#include "Communication.h"
+
+/************************* Functions Definitions ******************************/
+
+/**
+   @brief Initializes the AD7988
+
+   @param None.
+
+   @return None
+**/
+void AD7988_Init(void)
+{
+  pinMode(IN1ADG884_PIN, OUTPUT);
+  pinMode(A0ADG758_PIN, OUTPUT);
+  pinMode(A1ADG758_PIN, OUTPUT);
+  pinMode(A2ADG758_PIN, OUTPUT);
+  pinMode(IO6ADG758_PIN, OUTPUT);
+}
+
+/**
+   @brief Selects the desired gain resistor R1 to R5
+
+   @param mode - desired mode of operation
+
+   @return None
+**/
+void AD7988_SensorRangeSelect(enAD7988OpMode mode)
+{
+  uint8_t ui8A0Pin, ui8A1Pin, ui8A2Pin;
+
+  ui8A0Pin = (mode & 0x1) >> 0;
+  ui8A1Pin = (mode & 0x2) >> 1;
+  ui8A2Pin = (mode & 0x4) >> 2;
+
+  if (ui8A0Pin)
+    digitalWrite(A0ADG758_PIN, HIGH);
+  else
+    digitalWrite(A0ADG758_PIN, LOW);
+
+  if (ui8A1Pin)
+    digitalWrite(A1ADG758_PIN, HIGH);
+  else
+    digitalWrite(A1ADG758_PIN, LOW);
+
+  if (ui8A2Pin)
+    digitalWrite(A2ADG758_PIN, HIGH);
+  else
+    digitalWrite(A2ADG758_PIN, LOW);
+}
+
+/**
+   @brief Selects the desired mode of operation by enabling or disabling the power on the correct pins
+
+   @param mode - desired mode of operation
+
+   @return None
+**/
+void AD7988_SetOperationMode(enAD7988OpMode mode)
+{
+  if (mode == AD7988_RH_MODE) {
+    digitalWrite(IN1ADG884_PIN, HIGH); // set IN1 to logic 1
+    digitalWrite(IO6ADG758_PIN, LOW); // disable power on IO6
+  }
+  else {
+    digitalWrite(IN1ADG884_PIN, LOW); // reset IN1
+    digitalWrite(IO6ADG758_PIN, HIGH); // enable master power on IO6
+    AD7988_SensorRangeSelect(mode);
+  }
+  delay(1);
+}
+
+/**
+   @brief Reads AD7988 data from the SPI
+
+   @param data - read data.
+
+   @return None
+**/
+void AD7988_ReadData(uint16_t *data)
+{
+  *data =  SPI_Read();
+}
+
+/**
+   @brief Converts the read ADC data to the corresponding voltage
+
+   @param ui16Adcdata - ADC data read
+
+   @return fAdcVoltage -  voltage according to the input data
+**/
+float AD7988_DataToVoltage(uint16_t ui16Adcdata)
+{
+  float fAdcVoltage = 0;
+
+  fAdcVoltage = ((float)ui16Adcdata / (pow(2, 16) - 1) ) * ADC_VREF;
+
+  return fAdcVoltage;
+}

--- a/Arduino Uno R3/examples/CN0395_example/AD7988.h
+++ b/Arduino Uno R3/examples/CN0395_example/AD7988.h
@@ -1,0 +1,86 @@
+/*!
+ *****************************************************************************
+   @file:    AD7988.h
+   @brief:
+   @version: $Revision$
+   @date:    $Date$
+  -----------------------------------------------------------------------------
+
+  Copyright (c) 2017 Analog Devices, Inc.
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+  - Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+  - Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  - Modified versions of the software must be conspicuously marked as such.
+  - This software is licensed solely and exclusively for use with processors
+    manufactured by or for Analog Devices, Inc.
+  - This software may not be combined or merged with other code in any manner
+    that would cause the software to become subject to terms and conditions
+    which differ from those listed here.
+  - Neither the name of Analog Devices, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+  - The use of this software may or may not infringe the patent rights of one
+    or more patent holders.  This license does not release you from the
+    requirement that you obtain separate licenses from these patent holders
+    to use this software.
+
+  THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. AND CONTRIBUTORS "AS IS" AND ANY
+  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+  TITLE, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+  NO EVENT SHALL ANALOG DEVICES, INC. OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, DAMAGES ARISING OUT OF CLAIMS OF INTELLECTUAL
+  PROPERTY RIGHTS INFRINGEMENT; PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ *****************************************************************************/
+
+#ifndef AD7988_H_
+#define AD7988_H_
+
+#include <Arduino.h>
+
+/********************************* Global data ********************************/
+#define ADC_VREF  4.096 // V
+#define ADC_CODE_CALIBRATION  (((ADN8810_IFS * 71.5) / 1000) / ADC_VREF * 65535)
+
+/************************** Variable Definitions ******************************/
+typedef enum {
+  AD7988_DISABLE,
+  AD7988_ENABLE
+} enAD7988Status;
+
+typedef enum {             /* A2,   A1,   A0 */
+  AD7988_RS_RAMGE_1,      /* 0,    0,    0  */
+  AD7988_RS_RAMGE_2,      /* 0,    0,    1  */
+  AD7988_RS_RAMGE_3,      /* 0,    1,    0  */
+  AD7988_RS_RAMGE_4,      /* 0,    1,    1  */
+  AD7988_RS_RAMGE_5,      /* 1,    0,    0  */
+  AD7988_RH_MODE
+} enAD7988OpMode;
+
+/******************************************************************************/
+/* Functions Prototypes                                                       */
+/******************************************************************************/
+/* Initializes the AD7988 */
+void AD7988_Init(void);
+/* Selects the desired gain resistor R1 to R5 */
+void AD7988_SensorRangeSelect(enAD7988OpMode mode);
+/* Selects the desired mode of operation by enabling or disabling the power on the correct pins */
+void AD7988_SetOperationMode(enAD7988OpMode mode);
+/* Reads AD7988 data from the SPI */
+void AD7988_ReadData(uint16_t *data);
+/* Converts the read ADC data to the corresponding voltage */
+float AD7988_DataToVoltage(uint16_t ui16Adcdata);
+
+#endif //AD7988_H_

--- a/Arduino Uno R3/examples/CN0395_example/ADN8810.cpp
+++ b/Arduino Uno R3/examples/CN0395_example/ADN8810.cpp
@@ -1,0 +1,187 @@
+/*!
+ *****************************************************************************
+   @file:    ADN8810.c
+   @brief:   ADN8810 handling
+   @version: $Revision$
+   @date:    $Date$
+  -----------------------------------------------------------------------------
+
+  Copyright (c) 2018 Analog Devices, Inc.
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+  - Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+  - Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  - Modified versions of the software must be conspicuously marked as such.
+  - This software is licensed solely and exclusively for use with processors
+    manufactured by or for Analog Devices, Inc.
+  - This software may not be combined or merged with other code in any manner
+    that would cause the software to become subject to terms and conditions
+    which differ from those listed here.
+  - Neither the name of Analog Devices, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+  - The use of this software may or may not infringe the patent rights of one
+    or more patent holders.  This license does not release you from the
+    requirement that you obtain separate licenses from these patent holders
+    to use this software.
+
+  THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. AND CONTRIBUTORS "AS IS" AND ANY
+  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+  TITLE, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+  NO EVENT SHALL ANALOG DEVICES, INC. OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, DAMAGES ARISING OUT OF CLAIMS OF INTELLECTUAL
+  PROPERTY RIGHTS INFRINGEMENT; PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ *****************************************************************************/
+
+/***************************** Include Files **********************************/
+
+#include <Arduino.h>
+#include "ADN8810.h"
+#include "AD7988.h"
+#include "Communication.h"
+
+/************************* Functions Definitions ******************************/
+
+/**
+   @brief Initializes the ADN8810
+
+   @param None.
+
+   @return None
+**/
+void ADN8810_Init(void)
+{
+  pinMode(IO5ADN8810_PIN, OUTPUT); /* Set IO5ADN8810 pin as output */
+  pinMode(IO7ADN8810_PIN, OUTPUT); /* Set IO7ADN8810 pin as output */
+
+  ADN8810_MasterPower(ADN8810_ENABLE); //  enable master power on IO5
+
+  ADN8810_Reset(); // Reset DAC
+}
+
+/**
+   @brief ADN8810 IOUT Factory Calibration for 50mA FS
+
+   @param None.
+
+   @return fGainCorrectionFactor - the calculated gain correction factor
+**/
+uint32_t ADN8810_FactoryCalibration(void)
+{
+  uint16_t ui16AdcData = 0;
+  float fGainCorrectionFactor;
+  uint8_t ui8UpperByte = 0;       // Data byte MSB
+  uint8_t ui8LowerByte = 0;       // Data byte LSB
+  uint16_t ui16DacInputCode = ADN8810_FULL_SCALE_OUT; // Full Scale for 9.9mA
+
+  // build 12 bits of data + 4 bits of device address
+  ui8UpperByte = (uint8_t)(((ui16DacInputCode & 0xF00) >> 8) | (ADN8810_ADR << 4)); // 4 address and 4 data bits
+  ui8LowerByte = (uint8_t)(ui16DacInputCode & 0xFF); // 8 bits of data
+
+  ADN8810_MasterPower(ADN8810_ENABLE);                        // enable master power on IO5
+  digitalWrite(IO6ADG758_PIN, HIGH);                          // enable master power on IO6
+  digitalWrite(CSADN8810_PIN, LOW);                           // Set CS_N_ARD to logic 0
+  SPI_Write(ui8UpperByte, ui8LowerByte, SPI_WRITE_DAC_REG);   // Load FS code into ADN8810 DAC
+  digitalWrite(CSADN8810_PIN, HIGH);                          // Set CS_N_ARD to logic 1
+  digitalWrite(IN1ADG884_PIN, HIGH);                          // set IN1 to logic 1
+
+  delay(50);                                                  // delay 50ms
+  AD7988_ReadData(&ui16AdcData);                              // Read heater voltage ADC data
+
+  fGainCorrectionFactor = (ADC_CODE_CALIBRATION / ui16AdcData) * 10000;   // Calculate gain correction factor
+
+  return (uint32_t)fGainCorrectionFactor;
+}
+
+/**
+   @brief Set ADN8810 current output
+
+   @param fDesiredOutputCurrent - the desired IOUT current for ADN8810.
+
+ *        *sMeasVar - pointer to the struct that contains all the relevant measurement variables
+
+   @return -1 in case of error and 1 in case of success
+**/
+int ADN8810_SetOutput(float fDesiredOutputCurrent, sMeasurementVariables *sMeasVar)
+{
+  uint16_t ui16DacInputCode;
+  // Adjust the current with the gain correction factor
+  fDesiredOutputCurrent *= sMeasVar->K1;
+
+  if (fDesiredOutputCurrent > ADN8810_IFS) {
+    return -1;
+  }
+  else {
+    ui16DacInputCode = ADN8810_CurrentToDataInputCalc(fDesiredOutputCurrent); // Convert input current to a DAC value
+
+    uint8_t ui8UpperByte = 0;       /* Data byte MSB */
+    uint8_t ui8LowerByte = 0;       /* Data byte LSB */
+
+    /* build 12 bits of data + 4 bits of device address */
+    ui8UpperByte = (uint8_t)(((ui16DacInputCode & 0xF00) >> 8) | (ADN8810_ADR << 4)); // 4 address and 4 data bits
+    ui8LowerByte = (uint8_t)(ui16DacInputCode & 0xFF); // 8 bits of data
+
+    SPI_Write(ui8UpperByte, ui8LowerByte, SPI_WRITE_DAC_REG); // Load code into ADN8810 DAC
+
+    return 1;
+  }
+}
+
+
+/**
+  @brief Calculates the input code for ADN8810 IDAC, given a desired output current
+
+  @param fCurrent - desired output current between 2.4uA and 9.9mA
+
+  @return fCode - the value that will be received as input by the IDAC.
+**/
+uint16_t ADN8810_CurrentToDataInputCalc(float fCurrent)
+{
+  float fCode = 0;
+
+  fCode = fCurrent / ADN8810_CURRENT_1LSB;
+
+  return (uint16_t)fCode;
+}
+
+/**
+  @brief Enable/Disable power for ADN8810 by setting/resetting IO5
+
+  @param status - Enable or Disable
+
+  @return None.
+**/
+void ADN8810_MasterPower(enADN8810Status status)
+{
+  if (status == ADN8810_ENABLE)
+    digitalWrite(IO5ADN8810_PIN, HIGH); // enable master power on IO5
+  else if (status == ADN8810_DISABLE)
+    digitalWrite(IO5ADN8810_PIN, LOW);
+}
+
+/**
+  @brief Reset ADN8810
+
+  @param None
+
+  @return None.
+**/
+void ADN8810_Reset(void)
+{
+  /* Reset DAC: Make RESET IO7 logic 0 */
+  digitalWrite(IO7ADN8810_PIN, LOW);
+  delay(1); // delay 1ms
+  digitalWrite(IO7ADN8810_PIN, HIGH);
+}

--- a/Arduino Uno R3/examples/CN0395_example/ADN8810.h
+++ b/Arduino Uno R3/examples/CN0395_example/ADN8810.h
@@ -1,0 +1,84 @@
+/*!
+ *****************************************************************************
+   @file:    ADN8810.h
+   @brief:
+   @version: $Revision$
+   @date:    $Date$
+  -----------------------------------------------------------------------------
+
+  Copyright (c) 2017 Analog Devices, Inc.
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+  - Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+  - Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  - Modified versions of the software must be conspicuously marked as such.
+  - This software is licensed solely and exclusively for use with processors
+    manufactured by or for Analog Devices, Inc.
+  - This software may not be combined or merged with other code in any manner
+    that would cause the software to become subject to terms and conditions
+    which differ from those listed here.
+  - Neither the name of Analog Devices, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+  - The use of this software may or may not infringe the patent rights of one
+    or more patent holders.  This license does not release you from the
+    requirement that you obtain separate licenses from these patent holders
+    to use this software.
+
+  THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. AND CONTRIBUTORS "AS IS" AND ANY
+  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+  TITLE, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+  NO EVENT SHALL ANALOG DEVICES, INC. OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, DAMAGES ARISING OUT OF CLAIMS OF INTELLECTUAL
+  PROPERTY RIGHTS INFRINGEMENT; PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ *****************************************************************************/
+
+#ifndef ADN8810_H_
+#define ADN8810_H_
+
+#include <Arduino.h>
+#include "CN0395.h"
+
+/*****************************************************************************/
+/********************************  Definitions *******************************/
+/*****************************************************************************/
+// Comands
+
+#define ADN8810_ADR                 0x07   // Hard wired device address
+#define ADN8810_RSN                 41.2 // Ohms
+#define ADN8810_CURRENT_1LSB        (1 / (10 * ADN8810_RSN))      // For RSN = 41.2ohms, 1 LSB resolution = 2.4uA
+#define ADN8810_IFS                 ((ADC_VREF / ADN8810_RSN) * 100) // Full Scale current, for RSN = 41.2ohms, IFS = 9.94mA
+#define ADN8810_FULL_SCALE_OUT      4095
+#define ADN8810_HALF_SCALE_OUT      2048
+#define ADN8810_QUARTER_SCALE_OUT   1024
+
+typedef enum {
+  ADN8810_DISABLE,
+  ADN8810_ENABLE
+} enADN8810Status;
+
+
+/******************************************************************************/
+/* Functions Prototypes                                                       */
+/******************************************************************************/
+
+void ADN8810_Init(void);
+int ADN8810_SetOutput(float fDesiredOutputCurrent, sMeasurementVariables *sMeasVar);
+void ADN8810_Reset(void);
+void ADN8810_MasterPower(enADN8810Status status);
+uint32_t ADN8810_FactoryCalibration(void);
+uint16_t ADN8810_CurrentToDataInputCalc(float fCurrent);
+
+#endif // ADN8810_H_

--- a/Arduino Uno R3/examples/CN0395_example/CN0395.cpp
+++ b/Arduino Uno R3/examples/CN0395_example/CN0395.cpp
@@ -1,0 +1,868 @@
+/*!
+ *****************************************************************************
+   @file:    CN0395.c
+   @brief:
+   @version: $Revision$
+   @date:    $Date$
+  -----------------------------------------------------------------------------
+
+  Copyright (c) 2018 Analog Devices, Inc.
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+  - Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+  - Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  - Modified versions of the software must be conspicuously marked as such.
+  - This software is licensed solely and exclusively for use with processors
+    manufactured by or for Analog Devices, Inc.
+  - This software may not be combined or merged with other code in any manner
+    that would cause the software to become subject to terms and conditions
+    which differ from those listed here.
+  - Neither the name of Analog Devices, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+  - The use of this software may or may not infringe the patent rights of one
+    or more patent holders.  This license does not release you from the
+    requirement that you obtain separate licenses from these patent holders
+    to use this software.
+
+  THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. AND CONTRIBUTORS "AS IS" AND ANY
+  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+  TITLE, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+  NO EVENT SHALL ANALOG DEVICES, INC. OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, DAMAGES ARISING OUT OF CLAIMS OF INTELLECTUAL
+  PROPERTY RIGHTS INFRINGEMENT; PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ *****************************************************************************/
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include <Arduino.h>
+#include <SPI.h>
+#include <Wire.h>
+#include <EEPROM.h>
+
+#include "CN0395.h"
+#include "Communication.h"
+
+#include "ADN8810.h"
+#include "AD7988.h"
+#include "SHT30.h"
+
+/************************* Variable Definitions ******************************/
+
+uint32_t RsTime = 0;
+uint8_t ui8ContinousRsMeasurement = 0;
+
+/* Available commands */
+char *CmdCommands[] = {
+  "help",
+  "calibration",
+  "operation",
+  "current",
+  "voltage",
+  "resistance",
+  "temperature",
+  ""
+};
+
+/* Functions for available commands */
+cmdFunc CmdFun[] = {
+  CN0395_CmdHelp,
+  CN0395_CmdCalibration,
+  CN0395_CmdSetOpMode,
+  CN0395_CmdSetHeaterCurrent,
+  CN0395_CmdSetHeaterVoltage,
+  CN0395_CmdSetHeaterRes,
+  CN0395_CmdSetHeaterTemp,
+  NULL
+};
+
+/************************* Functions Definitions ******************************/
+/**
+   @brief Command line process function
+
+   @return none
+**/
+void CN0395_CmdProcess(sMeasurementVariables *sMeasVar)
+{
+  cmdFunc   func;
+
+  func = CN0395_FindCommand((char *)uart_rx_buffer);    /* Find needed function based on typed command */
+
+  if (func) {                                           /* Check if there is a valid command */
+    Serial.print("\n");
+    (*func)(&uart_rx_buffer[2], sMeasVar);             /* Call the desired function */
+  }
+  else if (strlen((char *)uart_rx_buffer) != 0) {       /* Check if there is no match for typed command */
+    Serial.print("\n");
+    Serial.print("Unknown command!");                     /* Display a message for unknown command */
+    Serial.print("\n");
+  }
+  else { // if just <ENTER> is pressed, make a new measurement and display RS data
+    ui8ContinousRsMeasurement ^= 1;
+  }
+}
+
+/**
+   @brief Find available commands
+
+   @param cmd - command to search
+
+   @return cmdFunc - return the specific function for available command or NULL for invalid command
+**/
+cmdFunc CN0395_FindCommand(char *cmd)
+{
+  cmdFunc func = NULL;
+  int i = 0;
+
+  while (CmdFun[i] != NULL) {
+    if (strncmp(cmd, CmdCommands[i], 6) == 0) {
+      func = CmdFun[i];
+      break;
+    }
+    i++;
+  }
+
+  return func;
+}
+
+/**
+   @brief Command Prompt function
+
+   @return res - UART_SUCCESS
+**/
+int CN0395_CmdPrompt(void)
+{
+  int res;
+
+  if (res == UART_SUCCESS) {
+    Serial.print('>');
+  }
+  uart_rcnt = 0;
+
+  return res;
+}
+
+/**
+   @brief Compute RH, PH and TH and update sMeasVar struct with the new values
+
+   @param sMeasVar - pointer to the struct that contains all the relevant measurement variables
+
+   @return None.
+**/
+void CN0395_ComputeHeaterRPT(sMeasurementVariables *sMeasVar)
+{
+  float    fHeaterVoltage;
+  float    fHeaterRes;
+  float    fAmbientHeaterTemp;
+  float    fAmbientHeaterHum;
+  float    fHeaterCurrent;
+  float    fHeaterPower;
+  float    fHeaterTemp;
+
+  const float fHeaterNomimalRes = 110; // RH_0 = 110Ω @ 20°C
+
+  fHeaterVoltage = sMeasVar->fHeaterVoltage;
+  fHeaterCurrent = sMeasVar->fHeaterCurrent;
+  // Calculate RH = VH/IH
+  fHeaterRes = (fHeaterVoltage / fHeaterCurrent) * pow(10, 3); // Ω
+
+  // Calculate PH = VH*IH
+  fHeaterPower = fHeaterVoltage * fHeaterCurrent; // mW
+
+  // Read T_A and HUM from temperature/humidity sensor
+  SHT30_Update(&fAmbientHeaterTemp, &fAmbientHeaterHum);
+
+  /* RH_T = RH_A [ 1 + ALPHA*(RH_0/RH_A)*(T – T_A)] - solve for T as a function of RH_T:
+     T =  (RH_T – RH_A) / (ALPHA * RH_0) + T_A
+  */
+  fHeaterTemp = (fHeaterRes - sMeasVar->fAmbientHeaterRes) / (ALPHA * fHeaterNomimalRes) + fAmbientHeaterTemp;
+
+  sMeasVar->fHeaterRes = fHeaterRes;
+  sMeasVar->fAmbientHeaterTemp = fAmbientHeaterTemp;
+  sMeasVar->fAmbientHeaterHum = fAmbientHeaterHum;
+  sMeasVar->fHeaterPower = fHeaterPower;
+  sMeasVar->fHeaterTemp = fHeaterTemp;
+}
+
+/**
+   @brief After initialization, circuit resets then measures heater ambient temperature T_A,
+          humidity HUM, then ambient temperature heater resistance RH_A. Save T_A, HUM, RH_A.
+          Also reads the correction factor (K1) from the permanent memory.
+          Moreover, it is assumed that init is performed in clean air, therefore we measure Ro.
+
+   @param sMeasVar - pointer to the struct that contains all the relevant measurement variables
+
+   @return None.
+**/
+void CN0395_PowerOn(sMeasurementVariables *sMeasVar)
+{
+  uint16_t ui16AdcData;
+  float    fHeaterVoltage;
+  float    fAmbientHeaterRes;
+  float    fAmbientHeaterTemp;
+  float    fAmbientHeaterHum;
+  uint32_t ui32CalibrationData[2];
+
+  // Enable master power on IO5 and reset DAC
+  ADN8810_Init();
+
+  // Switch to RH mode and disable RS switches, delay 50ms
+  AD7988_SetOperationMode(AD7988_RH_MODE);
+  sMeasVar->OpMode = AD7988_RH_MODE;
+
+  // Read from permanent memory the calibration data
+  EEPROM.get(0, ui32CalibrationData);
+
+  if (ui32CalibrationData[0] == 1) { // first element of the array is the information if calibration has been performed before
+    // The second element of the array is the gain calibration factor which needs to be converted from uint32_t to float
+    sMeasVar->K1 = (float)(ui32CalibrationData[1] / 10000) + (float)(ui32CalibrationData[1] % 10000) / 10000;
+  }
+  else {
+    // In the case that Factory Calibration has never been performed before, use gain calibration factor of 1
+    sMeasVar->K1 = 1;
+  }
+
+  delay(50);
+
+  // Set default heater current to 8mA
+  sMeasVar->fHeaterCurrent = 8;
+  ADN8810_SetOutput(sMeasVar->fHeaterCurrent, sMeasVar);
+
+  // Delay 20uS; this is long enough for DAC current to settle, but not long enough for heater temp to change
+  delayMicroseconds(20);
+
+  ui16AdcData = CN0395_ReadAdc(sMeasVar);
+  fHeaterVoltage = AD7988_DataToVoltage(ui16AdcData);
+  // Calculate RH_A = VH_A / 8mA
+  fAmbientHeaterRes = (fHeaterVoltage / sMeasVar->fHeaterCurrent) * pow(10, 3);
+
+  // Read T_A and HUM from temperature/humidity sensor
+  SHT30_Update(&fAmbientHeaterTemp, &fAmbientHeaterHum);
+
+  // Store some init measurement values for future calculations
+  sMeasVar->fAmbientHeaterRes = fAmbientHeaterRes;
+  sMeasVar->fHeaterVoltage = fHeaterVoltage;
+  sMeasVar->fAmbientHeaterTemp = fAmbientHeaterTemp;
+  sMeasVar->fAmbientHeaterHum = fAmbientHeaterHum;
+
+  CN0395_ComputeHeaterRPT(sMeasVar); // Compute RH, PH and TH
+
+  // At power up, perform a Ro measurement and store it for future use
+  sMeasVar->fSensorResCleanAir = CN0395_MeasureSensorResistance(sMeasVar);
+  while (sMeasVar->fSensorResCleanAir < 0) { // in case of error, repeat measurement
+    delay(500);
+    sMeasVar->fSensorResCleanAir = CN0395_MeasureSensorResistance(sMeasVar);
+  }
+}
+
+/**
+   @brief Routine for measuring sensor resistance RS:
+          - Set IO6 to logic 1 enable switches
+          - Set IN1 to logic 0 to connect ADC to RS sensor resistor
+          - Use the gain ranging algorithm to determine the value of RS
+
+   @param sMeasVar - pointer to the struct that contains all the relevant measurement variables
+
+   @return None.
+**/
+float CN0395_MeasureSensorResistance(sMeasurementVariables *sMeasVar)
+{
+  float    fRS = 0;
+  float    VS;
+  uint16_t ui16AdcData;
+  uint32_t ui32RgValue = 0;
+  int8_t  i8GainRangingIndex = AD7988_RS_RAMGE_5;
+  uint32_t GainRangingTh[5][4] = {
+    {442, 8870, 1922, 132},
+    {393, 39200, 10263, 3330},
+    {3468, 110000, 56753, 84000},
+    {3492, 2740000, 57175, 2119971},
+    {7171, 33300000, 62415, 1909936}
+  };
+
+  // Gain ranging algorithm, needs to be run with every sensor measurement
+  while (i8GainRangingIndex >= AD7988_RS_RAMGE_1) {
+
+    AD7988_SetOperationMode((enAD7988OpMode)i8GainRangingIndex);
+    sMeasVar->OpMode = i8GainRangingIndex;
+
+    ui16AdcData = CN0395_ReadAdc(sMeasVar);
+
+    if (ui16AdcData > GainRangingTh[i8GainRangingIndex][2]) {
+      Serial.print(F("\r\nADC Data Error  = "));
+      Serial.println(ui16AdcData);
+      return -1;
+    }
+    // ADC Data is bellow the threshold switch to the next gain
+    else if (ui16AdcData < GainRangingTh[i8GainRangingIndex][0]) {
+      i8GainRangingIndex--;
+    }
+    else { // ADC read data is in the correct range --> calculate RS
+      AD7988_SetOperationMode(AD7988_RH_MODE);
+      ui32RgValue = GainRangingTh[i8GainRangingIndex][1];
+      fRS = CN0395_CalculateRs(ui16AdcData, ui32RgValue);
+      VS = AD7988_DataToVoltage(ui16AdcData);
+      sMeasVar->fSensorVoltage = VS;
+      sMeasVar->ui32GainResistance = ui32RgValue;
+      sMeasVar->fSensorRes = fRS;
+      sMeasVar->fPPM = CN0395_CalculatePPM(sMeasVar);
+
+      if (fRS > GainRangingTh[i8GainRangingIndex][3]) { // RS exceeds max value
+        return -1;
+      }
+
+      return fRS;
+    }
+  }
+  return 0; // never reached
+}
+
+/**
+   @brief Display measured and calculation data (on UART).
+
+   @param sMeasVar - pointer to the struct that contains all the relevant measurement variables.
+
+   @return None.
+**/
+void CN0395_DisplayData(sMeasurementVariables *sMeasVar)
+{
+  char *percent = "%";
+
+  if (sMeasVar->OpMode == AD7988_RH_MODE) {
+    Serial.print(F("\r\nAvailable data for RH mode:"));
+    Serial.print(F("\r\n"));
+    Serial.print(F("\r\nAmbient Heater Res:  RH_A  = "));
+    Serial.print(sMeasVar->fAmbientHeaterRes); Serial.println(F(" [Ohms]"));
+    Serial.print(F("\r\nHeater Voltage:      VH    = "));
+    Serial.print(sMeasVar->fHeaterVoltage); Serial.println(F(" [V]"));
+    Serial.print(F("\r\nHeater Current:      IH    = "));
+    Serial.print(sMeasVar->fHeaterCurrent); Serial.println(F(" [mA]"));
+    Serial.print(F("\r\nHeater Resistance:   RH    = "));
+    Serial.print(sMeasVar->fHeaterRes); Serial.println(F(" [Ohms]"));
+    Serial.print(F("\r\nAmbient Heater Temp: T_A   = "));
+    Serial.print(sMeasVar->fAmbientHeaterTemp); Serial.println(F(" [C]"));
+    Serial.print(F("\r\nAmbient Heater Hum:  HUM   = "));
+    Serial.print(sMeasVar->fAmbientHeaterHum); Serial.println(percent);
+    Serial.print(F("\r\nHeater Power:        PH    = "));
+    Serial.print(sMeasVar->fHeaterPower); Serial.println(F(" [mW]"));
+    Serial.print(F("\r\nHeater Temp:         TH    = "));
+    Serial.print(sMeasVar->fHeaterTemp ); Serial.println(F(" [C]"));
+    Serial.print(F("\r\nADC Data                   = "));
+    Serial.print(F("0x")); Serial.println(sMeasVar->ui16LastAdcDataRead, HEX);
+    Serial.print(F("\r\nSensor Res Air:      Ro    = "));
+    Serial.print(sMeasVar->fSensorResCleanAir); Serial.println(F(" [Ohms]"));
+  }
+  else {
+    Serial.print(F("\r\nAvailable data for RS mode:"));
+    Serial.print(F("\r\n"));
+    Serial.print(F("\r\nSensor Resistance:      Rs    = "));
+    Serial.print(sMeasVar->fSensorRes); Serial.println(F(" [Ohms]"));
+    Serial.print(F("\r\nSensor Resistance Air:  Ro    = "));
+    Serial.print(sMeasVar->fSensorResCleanAir); Serial.println(F(" [Ohms]"));
+    Serial.print(F("\r\nGas Concentration       C     = "));
+    Serial.print(sMeasVar->fPPM); Serial.println(F(" [PPM]"));
+    Serial.print(F("\r\nSensor Voltage:         Vs    = "));
+    Serial.print(sMeasVar->fSensorVoltage); Serial.println(F(" [V]"));
+    Serial.print(F("\r\nHeater Voltage:         VH    = "));
+    Serial.print(sMeasVar->fHeaterVoltage); Serial.println(F(" [V]"));
+    Serial.print(F("\r\nAmbient Heater Temp:    T_A   = "));
+    Serial.print(sMeasVar->fAmbientHeaterTemp); Serial.println(F(" [C]"));
+    Serial.print(F("\r\nAmbient Heater Hum:     HUM   = "));
+    Serial.print(sMeasVar->fAmbientHeaterHum); Serial.println(percent);
+  }
+  Serial.print(F("\r\n"));
+}
+
+/**
+   @brief Display info for <help> command
+
+   @param args - pointer to the arguments on the command line.
+
+   @param sMeasVar - pointer to the struct that contains all the relevant measurement variables.
+
+   @return none
+**/
+void CN0395_CmdHelp(uint8_t *args, sMeasurementVariables *sMeasVar)
+{
+  uint8_t        *p = args;
+  char           arg[4];
+  while (*(p = CN0395_FindArgv(p)) != '\0') {         /* Check if this function gets an argument */
+    CN0395_GetArgv(arg, p);
+  }
+
+  Serial.print(F("\n"));
+  Serial.print(F("Available commands:\n"));
+  Serial.print(F("\n"));
+  Serial.print(F("Press the <ENTER> key  - Start/Stop continuous sensor measurement \n"));
+  Serial.print(F("operation <mode>       - Set the desired operation mode: heater or sensor and perform a single measurement \n"));
+  Serial.print(F("                         <mode> = RH, RS\n"));
+  Serial.print(F("calibration <r/w>      - Full scale calibration routine.\n"));
+  Serial.print(F("                         The calibration ensures that the exact ADN8810 output current is known\n"));
+  Serial.print(F("                         and the calibration constant (K1) is stored.\n"));
+  Serial.print(F("                         <r/w> = r read K1 stored in the permanent memory\n"));
+  Serial.print(F("                         <r/w> = w perform a factory calibration and store K1 in memory\n"));
+}
+
+/**
+   @brief Run the calibration routine and display the calibration correction factor
+
+   @param args - pointer to the arguments on the command line.
+
+   @param sMeasVar - pointer to the struct that contains all the relevant measurement variables.
+
+   @return none
+**/
+void CN0395_CmdCalibration(uint8_t *args, sMeasurementVariables *sMeasVar)
+{
+  uint8_t        *p = args;
+  char           arg[4];
+  uint32_t       ui32CalibrationData[2];
+  float          K1 = 0;
+
+  while (*(p = CN0395_FindArgv(p)) != '\0') {         /* Check if this function gets an argument */
+    CN0395_GetArgv(arg, p);
+  }
+
+  // Read the correction factor K1 stored in permanent memory
+  if (strncmp(arg, "r", 2) == 0) {
+    EEPROM.put(0, ui32CalibrationData);
+
+    if (ui32CalibrationData[0] == 1) { // this array also stores the information if calibration has already been performed
+      K1 = (float)(ui32CalibrationData[1] / 10000) + (float)(ui32CalibrationData[1] % 10000) / 10000;
+      Serial.print(F("\n"));
+      Serial.print(F("Gain correction factor (K1) stored in memory is: ")); Serial.print(K1);
+      Serial.print(F("\n"));
+    }
+    else {
+      Serial.print(F("\n"));
+      Serial.print(F("Factory calibration hasn't been performed yet, default K1 value is 1"));
+      Serial.print(F("\nType <calibrate w> to perform the factory calibration..."));
+      Serial.print(F("\n"));
+    }
+  }
+  // Perform a new calibration routine and store K1 in permanent memory
+  else if (strncmp(arg, "w", 2) == 0) {
+
+    Serial.print(F("\nPlace the P2 jumper between P2-1 and P2-2 (RCAL1) and press <c> key"));
+    Serial.print(F("\n"));
+
+    char response;
+    while (response != 'c') {
+      response = Serial.read();   // Read character from UART
+    }
+    Serial.print(F("\n"));
+
+    ui32CalibrationData[0] = 1; // Factory calibration has been performed, save this information in permanent memory
+    ui32CalibrationData[1] = ADN8810_FactoryCalibration(); // Save gain calibreation factor in permanent memory
+    EEPROM.put(0, ui32CalibrationData);
+
+    K1 = (float)(ui32CalibrationData[1] / 10000) + (float)(ui32CalibrationData[1] % 10000) / 10000;
+    sMeasVar->K1 = K1;
+    Serial.print(F("\n"));
+    Serial.print(F("Gain correction factor (K1) stored in memory is: ")); Serial.print(K1);
+    Serial.print(F("\n"));
+  }
+}
+
+/**
+   @brief Update operation mode according to operation command: RH, RS or RO
+
+   @param args - pointer to the arguments on the command line.
+
+   @param sMeasVar - pointer to the struct that contains all the relevant measurement variables.
+
+   @return none
+**/
+void CN0395_CmdSetOpMode(uint8_t *args, sMeasurementVariables *sMeasVar)
+{
+  uint8_t        *p = args;
+  char           arg[4];
+
+  while (*(p = CN0395_FindArgv(p)) != '\0') {         /* Check if this function gets an argument */
+    CN0395_GetArgv(arg, p);
+  }
+
+  if (strncmp(arg, "RH", 3) == 0) {
+    sMeasVar->OpMode = AD7988_RH_MODE;
+    Serial.print(F("\n\tHeater mode of operation\n"));
+    Serial.print(F("Input desired value...\n"));
+    Serial.print(F("\n"));
+    Serial.print(F("voltage <V>            - Constant Voltage (input voltage VH, 1.8V default)\n"));
+    Serial.print(F("                         <V> ex: 1.8, 2, ... \n"));
+    Serial.print(F("resistance <ohms>      - Constant Resistance (input resistance RH, 225Ohms default) \n"));
+    Serial.print(F("                         <ohms> ex: 225, ... \n"));
+    Serial.print(F("temperature <C>        - Constant T (input TH, 360 Celsius default)  \n"));
+    Serial.print(F("                         <C> ex: 360, ... \n"));
+    Serial.print(F("current <mA>           - Constant Current (Input IH, 8mA default)  \n"));
+    Serial.print(F("                         <mA> ex: 8.49, ... \n"));
+  }
+  else if (strncmp(arg, "RS", 3) == 0) {
+    CN0395_MeasureSensorResistance(sMeasVar);
+    CN0395_DisplayData(sMeasVar);
+  }
+}
+
+/**
+   @brief Routine for Setting Heater Current to Constant Current  IH (The default value is IH = 8mA)
+
+   @param sMeasVar - pointer to the struct that contains all the relevant measurement variables
+
+   @return None.
+**/
+void CN0395_CmdSetHeaterCurrent(uint8_t *args, sMeasurementVariables *sMeasVar)
+{
+  uint8_t  *p = args;
+  char     arg[3];
+  float    fDesiredHeaterCurrent;
+  uint16_t ui16AdcData;
+  float    fHeaterVoltage;
+
+  while (*(p = CN0395_FindArgv(p)) != '\0') {         /* Check if this function gets an argument */
+    CN0395_GetArgv(arg, p);
+  }
+
+  fDesiredHeaterCurrent = atof(arg); // convert string to float
+
+  if (ADN8810_SetOutput(fDesiredHeaterCurrent, sMeasVar) > 0) { // max current is 50 mA
+    AD7988_SetOperationMode(AD7988_RH_MODE);
+
+    ui16AdcData = CN0395_ReadAdc(sMeasVar);
+    fHeaterVoltage = AD7988_DataToVoltage(ui16AdcData);
+    delay(50); // delay 50ms
+
+    sMeasVar->fHeaterCurrent = fDesiredHeaterCurrent;
+    sMeasVar->fHeaterVoltage = fHeaterVoltage;
+    CN0395_ComputeHeaterRPT(sMeasVar); // Compute RH, PH and TH
+    // Update Ro value
+    sMeasVar->fSensorResCleanAir = CN0395_MeasureSensorResistance(sMeasVar);
+    while (sMeasVar->fSensorResCleanAir < 0) { // in case of error, repeat measurement
+      delay(500);
+      sMeasVar->fSensorResCleanAir = CN0395_MeasureSensorResistance(sMeasVar);
+    }
+    sMeasVar->OpMode = AD7988_RH_MODE;
+    CN0395_DisplayData(sMeasVar);
+  }
+  else {
+    Serial.print(F("\n"));
+    Serial.print(F("Cannot set heater current (IH) to ")); Serial.print(fDesiredHeaterCurrent);
+    Serial.print(F(". Maximum full scale current is ")); Serial.print(ADN8810_IFS); Serial.print(" mA!");
+    Serial.print(F("\n"));
+  }
+}
+
+/**
+   @brief Routine for error correction. Depending on the enSubroutine parameter, the correction is done either for voltage or resistance
+
+   @param sMeasVar - pointer to the struct that contains all the relevant measurement variables
+
+   @param fInputCurrent - input current
+
+   @param fDesiredValue - desired VH or desired RH
+
+   @param enSubroutine - RESISTANCE or VOLTAGE
+
+   @return None.
+**/
+static void CN0395_CorrectError(sMeasurementVariables *sMeasVar,
+                                float fInputCurrent,
+                                float fDesiredValue,
+                                enCN0395ErrCorrection enSubroutine)
+{
+  float    fError = 1;
+  uint16_t ui16AdcData = 0;
+  float    fVoltage = 0;
+  float    fActualValue;
+
+  while (fError > 0.005) { // repeat until the error is less than 0.5%
+    if (ADN8810_SetOutput(fInputCurrent, sMeasVar) > 0) {
+      delay(50); // delay 50ms for stabilization
+
+      ui16AdcData = CN0395_ReadAdc(sMeasVar);
+      fVoltage = AD7988_DataToVoltage(ui16AdcData); // Convert ADC data to Voltage
+
+      if (enSubroutine == RESISTANCE) {
+        fActualValue = (fVoltage / fInputCurrent) * pow(10, 3); // Constant resistance correction
+      }
+      else {
+        fActualValue = fVoltage; // Constant voltage correction
+      }
+
+      if (fDesiredValue > fActualValue) {
+        fError = (fDesiredValue - fActualValue) / fDesiredValue;  // calculate the error
+        fInputCurrent = fInputCurrent + fInputCurrent * 0.5 * fError; // correct IH for the error
+      }
+      else {
+        fError = (fActualValue - fDesiredValue) / fDesiredValue; // calculate the error
+        fInputCurrent = fInputCurrent - fInputCurrent * 0.5 * fError; // correct IH for the error
+      }
+    }
+    else {
+      Serial.print(F("\n"));
+      Serial.print(F("Cannot set heater current (IH) to ")); Serial.print(fInputCurrent);
+      Serial.print(F("Maximum full scale current is ")); Serial.print(ADN8810_IFS); Serial.print(F(" mA!"));
+      Serial.print("\n");
+      break;
+    }
+  }
+
+  sMeasVar->fHeaterVoltage = fVoltage;
+  sMeasVar->fHeaterCurrent = fInputCurrent;
+}
+
+
+/**
+   @brief Function for <voltage> command which calls the routine for setting heater voltage
+          to constant voltage VH and displays the available data.
+
+   @param sMeasVar - pointer to the struct that contains all the relevant measurement variables
+
+   @return None.
+**/
+void CN0395_CmdSetHeaterVoltage(uint8_t *args, sMeasurementVariables *sMeasVar)
+{
+  uint8_t  *p = args;
+  char     arg[3];
+  float    fDesiredVoltage;
+  float    fCurrent;
+  const uint8_t ui8HeaterRes = 225; // 225Ω
+
+  while (*(p = CN0395_FindArgv(p)) != '\0') {         /* Check if this function gets an argument */
+    CN0395_GetArgv(arg, p);
+  }
+  fDesiredVoltage = atof(arg); // convert string to float
+  fCurrent = (fDesiredVoltage / ui8HeaterRes) * pow(10, 3); // mA
+
+  AD7988_SetOperationMode(AD7988_RH_MODE);
+
+  CN0395_CorrectError(sMeasVar, fCurrent, fDesiredVoltage, VOLTAGE);
+
+  CN0395_ComputeHeaterRPT(sMeasVar); // Compute RH, PH and TH
+
+  // Update Ro value
+  sMeasVar->fSensorResCleanAir = CN0395_MeasureSensorResistance(sMeasVar);
+  while (sMeasVar->fSensorResCleanAir < 0) { // in case of error, repeat measurement
+    delay(500);
+    sMeasVar->fSensorResCleanAir = CN0395_MeasureSensorResistance(sMeasVar);
+  }
+  sMeasVar->OpMode = AD7988_RH_MODE;
+  CN0395_DisplayData(sMeasVar);
+}
+
+/**
+   @brief Function for <resistance> command which calls the routine for setting heater resistance
+          to constant resistance RH and displays the available data.
+
+   @param sMeasVar - pointer to the struct that contains all the relevant measurement variables
+
+   @return None.
+**/
+void CN0395_CmdSetHeaterRes(uint8_t *args, sMeasurementVariables *sMeasVar)
+{
+  uint8_t     *p = args;
+  char        arg[3];
+  float       fDesiredHeaterRes;
+  float       fCurrent = 8;
+  const float fHeaterRes = 110; // 110Ω @ 20°C
+
+  while (*(p = CN0395_FindArgv(p)) != '\0') {         /* Check if this function gets an argument */
+    CN0395_GetArgv(arg, p);
+  }
+
+  fDesiredHeaterRes = atof(arg); // convert string to float
+  // Note: The slope of the RH vs.IH curve is 115Ω/8mA = 14375Ω/A
+  fCurrent = ((fDesiredHeaterRes - fHeaterRes) / 14375) * pow(10, 3);
+
+  AD7988_SetOperationMode(AD7988_RH_MODE);
+
+  CN0395_CorrectError(sMeasVar, fCurrent, fDesiredHeaterRes, RESISTANCE);
+
+  CN0395_ComputeHeaterRPT(sMeasVar); // Compute RH, PH and TH
+
+  // Update Ro value
+  sMeasVar->fSensorResCleanAir = CN0395_MeasureSensorResistance(sMeasVar);
+  while (sMeasVar->fSensorResCleanAir < 0) { // in case of error, repeat measurement
+    delay(500);
+    sMeasVar->fSensorResCleanAir = CN0395_MeasureSensorResistance(sMeasVar);
+  }
+  sMeasVar->OpMode = AD7988_RH_MODE;
+  CN0395_DisplayData(sMeasVar);
+}
+
+/**
+   @brief Routine for Setting Heater Temperature to Constant Temperature TH (The default value is TH = 360 C)
+
+   @param *sMeasVar - pointer to the struct that contains all the relevant measurement variables
+
+   @return None.
+**/
+void CN0395_CmdSetHeaterTemp(uint8_t *args, sMeasurementVariables *sMeasVar)
+{
+  uint8_t     *p = args;
+  char        arg[3];
+  float       fDesiredHeaterTemp;
+  float       fAmbientHeaterTemp;
+  float       fDesiredHeaterRes;
+  float       fAmbientHeaterRes;
+  float       fHum;
+  float       fCurrent = 8;
+  const float fDefaultHeaterRes = 110; // 110Ω @ 20°C
+
+  while (*(p = CN0395_FindArgv(p)) != '\0') {         /* Check if this function gets an argument */
+    CN0395_GetArgv(arg, p);
+  }
+
+  fDesiredHeaterTemp = atof(arg); // convert string to float
+
+  SHT30_Update(&fAmbientHeaterTemp, &fHum);
+
+  AD7988_SetOperationMode(AD7988_RH_MODE);
+
+  fAmbientHeaterRes = sMeasVar->fAmbientHeaterRes; // get RH_A set initially at power on
+
+  // RH_T = RH_A [ 1 + ALPHA*(RH_0/RH_A)*(T – T_A)]
+  fDesiredHeaterRes = fAmbientHeaterRes *
+                      (1 + ALPHA * (fDefaultHeaterRes / fAmbientHeaterRes) * (fDesiredHeaterTemp - fAmbientHeaterTemp));
+
+  CN0395_CorrectError(sMeasVar, fCurrent, fDesiredHeaterRes, RESISTANCE);
+
+  CN0395_CorrectError(sMeasVar, fCurrent, sMeasVar->fHeaterVoltage, VOLTAGE);
+
+  CN0395_ComputeHeaterRPT(sMeasVar); // Compute RH, PH and TH
+  // Update Ro value
+  sMeasVar->fSensorResCleanAir = CN0395_MeasureSensorResistance(sMeasVar);
+  while (sMeasVar->fSensorResCleanAir < 0) { // in case of error, repeat measurement
+    delay(500);
+    sMeasVar->fSensorResCleanAir = CN0395_MeasureSensorResistance(sMeasVar);
+  }
+  sMeasVar->OpMode = AD7988_RH_MODE;
+  CN0395_DisplayData(sMeasVar);
+}
+
+/**
+   @brief Read ADC data
+
+   @param None.
+
+   @return ui16Adcdata - data read from ADC via SPI.
+**/
+uint16_t CN0395_ReadAdc(sMeasurementVariables *sMeasVar)
+{
+  uint16_t ui16Adcdata;
+
+  for (uint8_t i = 0; i < 5; i++) { // Ignore the first readings until the voltage stabilizes
+    AD7988_ReadData(&ui16Adcdata); // Read ADC data
+  }
+
+  sMeasVar->ui16LastAdcDataRead = ui16Adcdata;
+
+  return ui16Adcdata;
+}
+
+/**
+   @brief Calculate RS value
+
+   @param ui16Adcdata - ADC code
+   @param ui32RgValue - Gain resistance value
+
+   @return fRsValue - RS value.
+**/
+float CN0395_CalculateRs(uint16_t ui16Adcdata, uint32_t ui32RgValue)
+{
+  float fRsValue;
+
+  fRsValue = ((float)ui16Adcdata * 0.5 * (float)ui32RgValue ) / ((float)65536 - 0.5 * (float)ui16Adcdata);
+
+  return fRsValue;
+}
+
+/**
+   @brief Calculate gas concentration in PPM
+
+   @param *sMeasVar - pointer to the struct that contains all the relevant measurement variables
+
+   @return fConcentration - gas concentration in PPM
+**/
+float CN0395_CalculatePPM(sMeasurementVariables *sMeasVar)
+{
+  float fConcentration = 0;
+  float fRs = sMeasVar->fSensorRes;
+  float fRo = sMeasVar->fSensorResCleanAir;
+
+  if ( ((fRs / fRo) >= 0.25) && ((fRs / fRo) <= 0.6) ) {
+    fConcentration = 2.61 * pow((fRs / fRo), -2.63);
+  }
+  else if ((fRs / fRo) > 0.6) {
+    fConcentration = 0.550 * pow((fRs / fRo), -5.68);
+  }
+
+  return fConcentration;
+}
+
+/**
+   @brief Finds the next command line argument
+
+   @param args - pointer to the arguments on the command line.
+
+   @return pointer to the next argument.
+
+**/
+uint8_t *CN0395_FindArgv(uint8_t *args)
+{
+  uint8_t  *p = args;
+  int         fl = 0;
+
+  while (*p != 0) {
+    if ((*p == _SPC)) {
+      fl = 1;
+
+    } else {
+      if (fl) {
+        break;
+      }
+    }
+
+    p++;
+  }
+
+  return p;
+}
+
+/**
+   @brief Separates a command line argument
+
+    @param dst - pointer to a buffer where the argument will be copied
+    @param args - pointer to the current position of the command line .
+
+   @return none
+
+**/
+void CN0395_GetArgv(char *dst, uint8_t *args)
+{
+  uint8_t  *s = args;
+  char     *d = dst;
+
+  while (*s) {
+    if (*s == _SPC) {
+      break;
+    }
+
+    *d++ = *s++;
+  }
+
+  *d = '\0';
+}

--- a/Arduino Uno R3/examples/CN0395_example/CN0395.h
+++ b/Arduino Uno R3/examples/CN0395_example/CN0395.h
@@ -1,0 +1,124 @@
+/*!
+ *****************************************************************************
+   @file:    CN0395.h
+   @brief:
+   @version: $Revision$
+   @date:    $Date$
+  -----------------------------------------------------------------------------
+
+  Copyright (c) 2017 Analog Devices, Inc.
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+  - Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+  - Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  - Modified versions of the software must be conspicuously marked as such.
+  - This software is licensed solely and exclusively for use with processors
+    manufactured by or for Analog Devices, Inc.
+  - This software may not be combined or merged with other code in any manner
+    that would cause the software to become subject to terms and conditions
+    which differ from those listed here.
+  - Neither the name of Analog Devices, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+  - The use of this software may or may not infringe the patent rights of one
+    or more patent holders.  This license does not release you from the
+    requirement that you obtain separate licenses from these patent holders
+    to use this software.
+
+  THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. AND CONTRIBUTORS "AS IS" AND ANY
+  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+  TITLE, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+  NO EVENT SHALL ANALOG DEVICES, INC. OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, DAMAGES ARISING OUT OF CLAIMS OF INTELLECTUAL
+  PROPERTY RIGHTS INFRINGEMENT; PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ *****************************************************************************/
+
+#ifndef CN0395_H_
+#define CN0395_H_
+
+
+#include <Arduino.h>
+/********************************* Global data ********************************/
+#define ALPHA      0.003074
+
+/****************************** Internal types *********************************/
+typedef struct {
+  float       fAmbientHeaterTemp;  // T_A
+  float       fAmbientHeaterHum;   // HUM
+  float       fAmbientHeaterRes;   // RH_A
+  float       fHeaterVoltage;      // VH
+  float       fHeaterCurrent;      // IH
+  float       fHeaterRes;          // RH
+  float       fHeaterTemp;         // TH
+  float       fHeaterPower;        // PH
+  float       fSensorRes;          // RS
+  float       fSensorResCleanAir;  // Ro
+  float       fSensorVoltage;      // VS
+  float       fPPM;                // PPM
+  uint32_t    ui32GainResistance;  // RG
+  uint16_t    ui16LastAdcDataRead;
+  uint8_t     OpMode;
+  float       K1;                  // Gain correction factor
+} sMeasurementVariables;
+
+typedef enum {
+  VOLTAGE,
+  RESISTANCE
+} enCN0395ErrCorrection;
+
+typedef  void (*cmdFunc)(uint8_t *, sMeasurementVariables *);
+
+/******************************************************************************/
+/* Functions Prototypes                                                       */
+/******************************************************************************/
+/* Command line process function */
+void CN0395_CmdProcess(sMeasurementVariables *sMeasVar);
+/* Find available commands */
+cmdFunc CN0395_FindCommand(char *cmd);
+/* Command Prompt function */
+int CN0395_CmdPrompt(void);
+/* Function which performs the power up routine */
+void CN0395_PowerOn(sMeasurementVariables *sMeas);
+/* Routine for measuring sensor resistance RS */
+float CN0395_MeasureSensorResistance(sMeasurementVariables *sMeasVar);
+/* Display measured and calculation data (on UART) */
+void CN0395_DisplayData(sMeasurementVariables *sMeasVar);
+/* Display info for <help> command */
+void CN0395_CmdHelp(uint8_t *args, sMeasurementVariables *sMeasVar);
+/* Run the calibration routine and display the calibration correction factor */
+void CN0395_CmdCalibration(uint8_t *args, sMeasurementVariables *sMeasVar);
+/* Update operation mode according to operation command: RH, RS or RO */
+void CN0395_CmdSetOpMode(uint8_t *args, sMeasurementVariables *sMeasVar);
+/* Routine for Setting Heater Current to Constant Current  IH */
+void CN0395_CmdSetHeaterCurrent(uint8_t *args, sMeasurementVariables *sMeasVar);
+/* Function for <voltage> command which calls the routine for setting heater voltage */
+void CN0395_CmdSetHeaterVoltage(uint8_t *args, sMeasurementVariables *sMeasVar);
+/* Function for <resistance> command which calls the routine for setting heater resistance */
+void CN0395_CmdSetHeaterRes(uint8_t *args, sMeasurementVariables *sMeasVar);
+/*  Routine for Setting Heater Temperature to Constant Temperature TH  */
+void CN0395_CmdSetHeaterTemp(uint8_t *args, sMeasurementVariables *sMeasVar);
+/* Read ADC data */
+uint16_t CN0395_ReadAdc(sMeasurementVariables *sMeasVar);
+/* Calculate RS value */
+float CN0395_CalculateRs(uint16_t ui16Adcdata, uint32_t ui32RgValue);
+/* Calculate gas concentration in PPM */
+float CN0395_CalculatePPM(sMeasurementVariables *sMeasVar);
+/* Finds the next command line argument */
+uint8_t *CN0395_FindArgv(uint8_t *args);
+/* Separates a command line argument */
+void CN0395_GetArgv(char *dst, uint8_t *args);
+void CN0395_ComputeHeaterRPT(sMeasurementVariables *sMeasVar);
+
+#endif

--- a/Arduino Uno R3/examples/CN0395_example/CN0395_example.ino
+++ b/Arduino Uno R3/examples/CN0395_example/CN0395_example.ino
@@ -1,0 +1,107 @@
+#include <SPI.h>
+#include <Wire.h>
+
+#include "AD7988.h"
+#include "CN0395.h"
+#include "ADN8810.h"
+#include "SHT30.h"
+#include "Communication.h"
+
+static uint8_t count = 0;
+sMeasurementVariables *sMeasVar;
+extern uint8_t ui8ContinousRsMeasurement;
+
+void setup() {
+  Serial.begin(9600);
+  /* Initialize SPI */
+  SPI.begin();
+  SPI.setDataMode(SPI_MODE0); //CPHA = CPOL = 0    MODE = 0
+
+  pinMode(CSAD7988_PIN, OUTPUT);
+  pinMode(CSADN8810_PIN, OUTPUT);
+  digitalWrite(CSAD7988_PIN, HIGH);
+  digitalWrite(CSADN8810_PIN, HIGH);
+
+  /* Initialize I2C */
+  Wire.begin();
+
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
+
+  sMeasVar = (sMeasurementVariables *)malloc(sizeof(*sMeasVar));
+
+  AD7988_Init(); // Initialize ADC
+
+  CN0395_PowerOn(sMeasVar);
+}
+
+void loop() {
+  unsigned short  status;
+
+  if (uart_cmd == UART_TRUE) {  /* condition becomes true when the system receives as Carriage Return(CR) command from the UART */
+    if (count == 0) { // Check first <ENTER> is pressed after reset
+      Serial.print("\tWelcome to CN0395 application!\n");
+      Serial.print("\r\nDefault at power up: \n");
+      Serial.print("\r\n* RS operation mode\n");
+      Serial.print("\r* IH = 8 mA (Constant current)\n");
+      Serial.print("\r* Ro = "); Serial.print(sMeasVar->fSensorResCleanAir); Serial.print(" [Ohms] (Sensor resistance in clean air)\n");
+      Serial.print("\r\n>>Type in <help> to see available commands\n");
+
+      count++;
+    }
+    else { // At a second <ENTER> press, do the processing
+      CN0395_CmdProcess(sMeasVar);
+    }
+    uart_cmd = UART_FALSE;
+    CN0395_CmdPrompt();
+  }
+  if (ui8ContinousRsMeasurement) {
+
+    uint16_t ui16AdcData = 0;
+    float    fHeaterVoltage = 0;
+
+    AD7988_SetOperationMode(AD7988_RH_MODE);
+    ui16AdcData = CN0395_ReadAdc(sMeasVar);
+    fHeaterVoltage = AD7988_DataToVoltage(ui16AdcData);
+    delay(50); // delay 50ms
+
+    sMeasVar->fHeaterVoltage = fHeaterVoltage;
+    CN0395_ComputeHeaterRPT(sMeasVar); // Compute RH, PH and TH
+
+    CN0395_MeasureSensorResistance(sMeasVar);
+    delay(998);
+    CN0395_DisplayData(sMeasVar);
+  }
+}
+
+void serialEvent() {
+  char c;
+
+  while (Serial.available() > 0) {
+    c = Serial.read();                          /* Read character from UART */
+    switch (c) {
+      case _BS:
+        if (uart_rcnt) {
+          uart_rcnt--;
+          uart_rx_buffer[uart_rcnt] = 0;
+          Serial.write(c);
+          Serial.write(' ');
+          Serial.write(c);
+        }
+        break;
+      case _CR: /* Check if read character is ENTER */
+        uart_cmd = UART_TRUE;                    /* Set flag */
+        break;
+
+      default:
+        uart_rx_buffer[uart_rcnt++] = c;
+
+        if (uart_rcnt == UART_RX_BUFFER_SIZE) {
+          uart_rcnt--;
+        }
+    }
+
+    uart_rx_buffer[uart_rcnt] = '\0';
+  }
+}

--- a/Arduino Uno R3/examples/CN0395_example/Communication.cpp
+++ b/Arduino Uno R3/examples/CN0395_example/Communication.cpp
@@ -1,0 +1,152 @@
+/*!
+ *****************************************************************************
+   @file:    Communication.c
+   @brief:
+   @version: $Revision$
+   @date:    $Date$
+  -----------------------------------------------------------------------------
+
+  Copyright (c) 2015-2018 Analog Devices, Inc.
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+  - Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+  - Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  - Modified versions of the software must be conspicuously marked as such.
+  - This software is licensed solely and exclusively for use with processors
+    manufactured by or for Analog Devices, Inc.
+  - This software may not be combined or merged with other code in any manner
+    that would cause the software to become subject to terms and conditions
+    which differ from those listed here.
+  - Neither the name of Analog Devices, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+  - The use of this software may or may not infringe the patent rights of one
+    or more patent holders.  This license does not release you from the
+    requirement that you obtain separate licenses from these patent holders
+    to use this software.
+
+  THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. AND CONTRIBUTORS "AS IS" AND ANY
+  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+  TITLE, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+  NO EVENT SHALL ANALOG DEVICES, INC. OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, DAMAGES ARISING OUT OF CLAIMS OF INTELLECTUAL
+  PROPERTY RIGHTS INFRINGEMENT; PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ *****************************************************************************/
+
+/***************************** Include Files **********************************/
+#include "Communication.h"
+
+#include "ADN8810.h"
+#include "SHT30.h"
+/************************** Variable Definitions ******************************/
+
+unsigned char           uart_rx_buffer[UART_RX_BUFFER_SIZE];
+unsigned char           uart_tx_buffer[UART_TX_BUFFER_SIZE];
+
+unsigned int         uart_rpos, uart_rcnt, uart_tpos, uart_tcnt;
+unsigned int         uart_echo, uart_cmd, uart_ctrlc, uart_tbusy;
+
+uint8_t i2c_rx_buf[6];
+uint8_t i2c_rx_cnt = 0;
+
+/************************* Functions Definitions ******************************/
+/**
+   @brief Writes a register to the Converter via SPI.
+
+   @param ui8address - DAC register address
+   @param ui8Data - value to be written
+   @enMode ui8Data - write mode
+
+   @return none
+
+**/
+void SPI_Write(uint8_t ui8address, uint8_t ui8data, enWriteData enMode)
+{
+
+  if (SPI_WRITE_DAC_REG == enMode) { /* Select ADN8810 */
+    /* Set ADN8810 CS low */
+    digitalWrite(CSADN8810_PIN, LOW);
+
+    /* Send first byte */
+    SPI.transfer(ui8address);
+    /* Send second data byte */
+    SPI.transfer(ui8data); // 8 data bits
+
+    /* Set ADN8810 CS high */
+    digitalWrite(CSADN8810_PIN, HIGH);
+  }
+}
+
+/**
+   @brief Reads a specified register or two registers address in the accelerometer via SPI.
+
+   @param ui8address - register address
+   @param enRegs - register number
+
+   @return reading result
+
+**/
+uint16_t SPI_Read(void)
+{
+  uint8_t ui8AdcUpperCodes = 0;        /* Data register read MSB */
+  uint8_t ui8AdcLowerCodes = 0;        /* Data register read LSB */
+  uint16_t ui16Result = 0;
+
+  /* Start conversion by briefly setting the CNV pin high*/
+  digitalWrite(CSAD7988_PIN, HIGH);
+  /* Set AD7988 CS low */
+  digitalWrite(CSAD7988_PIN, LOW);
+
+  /* Send dummy bytes in order to receive the register value */
+  ui8AdcUpperCodes = SPI.transfer(0x07); /* Data register read MSB */
+  ui8AdcLowerCodes = SPI.transfer(0xAA); /* Data register read LSB */
+
+  ui16Result = ((uint16_t)ui8AdcUpperCodes << 8) | ui8AdcLowerCodes;
+
+  return ui16Result;
+}
+/**
+  @brief Write data to I2C
+
+  @param ui16Data - Data to write
+
+  @return none
+
+**/
+void I2C_Write(uint16_t ui16Data)
+{
+  uint8_t ui8UpperByte = 0;
+  uint8_t ui8LowerByte = 0;
+
+  ui8UpperByte = (uint8_t)((ui16Data & 0xFF00) >> 8);
+  ui8LowerByte = (uint8_t)(ui16Data  & 0xFF);
+  Wire.beginTransmission(SHT30_ADDR);
+  Wire.write(ui8UpperByte);
+  Wire.write(ui8LowerByte);
+  Wire.endTransmission();
+}
+
+/**
+  @brief Read data from I2C
+
+  @param none
+
+  @return none
+
+**/
+void I2C_Read(void)
+{
+  Wire.requestFrom(SHT30_ADDR, 6);
+}

--- a/Arduino Uno R3/examples/CN0395_example/Communication.h
+++ b/Arduino Uno R3/examples/CN0395_example/Communication.h
@@ -1,0 +1,137 @@
+/*!
+ *****************************************************************************
+   @file:    Communication.h
+   @brief:
+   @version: $Revision$
+   @date:    $Date$
+  -----------------------------------------------------------------------------
+
+  Copyright (c) 2015-2017 Analog Devices, Inc.
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+  - Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+  - Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  - Modified versions of the software must be conspicuously marked as such.
+  - This software is licensed solely and exclusively for use with processors
+    manufactured by or for Analog Devices, Inc.
+  - This software may not be combined or merged with other code in any manner
+    that would cause the software to become subject to terms and conditions
+    which differ from those listed here.
+  - Neither the name of Analog Devices, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+  - The use of this software may or may not infringe the patent rights of one
+    or more patent holders.  This license does not release you from the
+    requirement that you obtain separate licenses from these patent holders
+    to use this software.
+
+  THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. AND CONTRIBUTORS "AS IS" AND ANY
+  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+  TITLE, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+  NO EVENT SHALL ANALOG DEVICES, INC. OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, DAMAGES ARISING OUT OF CLAIMS OF INTELLECTUAL
+  PROPERTY RIGHTS INFRINGEMENT; PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ *****************************************************************************/
+
+#ifndef _COMMUNICATION_H_
+#define _COMMUNICATION_H_
+
+#include <Arduino.h>
+#include <SPI.h>
+#include <Wire.h>
+/*********************Pins configuration*******************/
+
+
+/* IN1ADG884 - 0.3 - output */
+#define IN1ADG884_PIN         10
+
+/* CSAD7988 - 0.4 - output */
+#define CSAD7988_PIN          9
+
+/** ADN8810 pin configuration  */
+/* CSADN8810 - 0.5 - output */
+#define CSADN8810_PIN            8
+
+/* IO7ADN8810 - 2.2 - output */
+#define IO7ADN8810_PIN           7
+
+/* IO5ADN8810 - 1.3 - output */
+#define IO5ADN8810_PIN           5
+
+/** ADG758 pin configuration  */
+/* A0ADG758 - 1.0 - output */
+#define A0ADG758_PIN          2
+
+/* A1ADG758 - 1.1 - output */
+#define A1ADG758_PIN          3
+
+/* A2ADG758 - 1.2 - output */
+#define A2ADG758_PIN          4
+
+/* IO6ADG758 - 1.4 - output */
+#define IO6ADG758_PIN         6
+
+/* -------------------------------------------------------------------------*/
+
+/* Write data mode */
+typedef enum {
+  SPI_WRITE_DAC_REG = 1,      /* Write data to DAC */
+  SPI_WRITE_DAC_FULL_SCALE,   /* Write FULL SCALE to DAC */
+  UART_WRITE_NO_INT,          /* Write data when interrupts are disabled */
+  UART_WRITE_IN_INT,          /* Write data while in an interrupt routine */
+  UART_WRITE
+} enWriteData;
+
+/* Execution status */
+#define UART_SUCCESS             0
+#define UART_FAILURE            -1
+#define UART_NO_TX_SPACE        -2
+#define UART_NO_RX_SPACE        -3
+
+/* UART status */
+#define UART_TRUE               1
+#define UART_FALSE              0
+
+#define _CR                      13      /* <ENTER> */
+#define _LF                      10      /* <New line> */
+#define _SPC                     32      /* <Space> */
+#define _BS                      8       /* <Backspace> */
+
+/* Buffer size for UART Tx and Rx */
+#define UART_TX_BUFFER_SIZE      1024       // UART transmit buffer size
+#define UART_RX_BUFFER_SIZE      256        // UART receive buffer size
+
+extern unsigned int       uart_rpos, uart_rcnt, uart_tpos, uart_tcnt;
+extern unsigned int       uart_echo, uart_cmd, uart_ctrlc, uart_tbusy;
+
+extern unsigned char      uart_rx_buffer[UART_RX_BUFFER_SIZE];
+extern unsigned char      uart_tx_buffer[UART_TX_BUFFER_SIZE];
+
+extern uint8_t i2c_rx_buf[6];
+extern uint8_t i2c_rx_cnt;
+
+/******************************************************************************/
+/* Functions Prototypes                                                       */
+/******************************************************************************/
+
+/* SPI Functions */
+uint16_t SPI_Read(void);
+void SPI_Write(uint8_t ui8address, uint8_t ui8data, enWriteData enMode);
+
+/* I2C Functions */
+void I2C_Write(uint16_t ui16Data);
+void I2C_Read(void);
+
+#endif /* _COMMUNICATION_H_ */

--- a/Arduino Uno R3/examples/CN0395_example/SHT30.cpp
+++ b/Arduino Uno R3/examples/CN0395_example/SHT30.cpp
@@ -1,0 +1,79 @@
+/*!
+ *****************************************************************************
+   @file:    SHT30.c
+   @brief:   SHT30 sensor
+   @version: $Revision$
+   @date:    $Date$
+  -----------------------------------------------------------------------------
+
+  Copyright (c) 2017 Analog Devices, Inc.
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+  - Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+  - Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  - Modified versions of the software must be conspicuously marked as such.
+  - This software is licensed solely and exclusively for use with processors
+    manufactured by or for Analog Devices, Inc.
+  - This software may not be combined or merged with other code in any manner
+    that would cause the software to become subject to terms and conditions
+    which differ from those listed here.
+  - Neither the name of Analog Devices, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+  - The use of this software may or may not infringe the patent rights of one
+    or more patent holders.  This license does not release you from the
+    requirement that you obtain separate licenses from these patent holders
+    to use this software.
+
+  THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. AND CONTRIBUTORS "AS IS" AND ANY
+  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+  TITLE, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+  NO EVENT SHALL ANALOG DEVICES, INC. OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, DAMAGES ARISING OUT OF CLAIMS OF INTELLECTUAL
+  PROPERTY RIGHTS INFRINGEMENT; PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ *****************************************************************************/
+
+/***************************** Include Files **********************************/
+#include <stdlib.h>
+#include <stdarg.h>
+#include <math.h>
+
+#include "Communication.h"
+#include "SHT30.h"
+
+/**************************** Global functions *******************************/
+
+void SHT30_Update(float *fTemp,  float *fHum)
+{
+  uint16_t ui16RawTemp;
+  uint16_t ui16RawHum;
+
+  I2C_Write(SHT30_MEAS_HIGHREP_PERIODIC);
+
+  delay(5); // delay 5ms
+
+  I2C_Read();
+
+  while (Wire.available())
+    i2c_rx_buf[i2c_rx_cnt++] = Wire.read();
+
+  i2c_rx_cnt = 0; // reload the i2c rx buffer index
+
+  ui16RawTemp = ((uint16_t)i2c_rx_buf[0] << 8) | i2c_rx_buf[1];
+  ui16RawHum = ((uint16_t)i2c_rx_buf[3] << 8) | i2c_rx_buf[4];
+
+  *fTemp = (float)((uint32_t)ui16RawTemp * 175) / (pow(2, 16) - 1) - 45;
+  *fHum = (float)((uint32_t)ui16RawHum * 100) / (pow(2, 16) - 1);
+}

--- a/Arduino Uno R3/examples/CN0395_example/SHT30.h
+++ b/Arduino Uno R3/examples/CN0395_example/SHT30.h
@@ -1,0 +1,72 @@
+/*!
+ *****************************************************************************
+   @file:    SHT30.h
+   @brief:   SHT30 sensor handling
+   @version: $Revision$
+   @date:    $Date$
+  -----------------------------------------------------------------------------
+
+  Copyright (c) 2017 Analog Devices, Inc.
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+  - Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+  - Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  - Modified versions of the software must be conspicuously marked as such.
+  - This software is licensed solely and exclusively for use with processors
+    manufactured by or for Analog Devices, Inc.
+  - This software may not be combined or merged with other code in any manner
+    that would cause the software to become subject to terms and conditions
+    which differ from those listed here.
+  - Neither the name of Analog Devices, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+  - The use of this software may or may not infringe the patent rights of one
+    or more patent holders.  This license does not release you from the
+    requirement that you obtain separate licenses from these patent holders
+    to use this software.
+
+  THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. AND CONTRIBUTORS "AS IS" AND ANY
+  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+  TITLE, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+  NO EVENT SHALL ANALOG DEVICES, INC. OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, DAMAGES ARISING OUT OF CLAIMS OF INTELLECTUAL
+  PROPERTY RIGHTS INFRINGEMENT; PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ *****************************************************************************/
+
+#ifndef SHT30_H_
+#define SHT30_H_
+
+#include <Arduino.h>
+
+#define SHT30_ADDR                     (uint8_t)0x45 //>> 1 ADDR pin connected to VDD
+
+#define SHT30_MEAS_HIGHREP_STRETCH     0x2C06
+#define SHT30_MEAS_MEDREP_STRETCH      0x2C0D
+#define SHT30_MEAS_LOWREP_STRETCH      0x2C10
+#define SHT30_MEAS_HIGHREP             0x2400
+#define SHT30_MEAS_MEDREP              0x240B
+#define SHT30_MEAS_LOWREP              0x2416
+
+#define SHT30_MEAS_HIGHREP_PERIODIC    0x2737
+#define SHT30_FETCH_DATA               0xE000
+
+#define SHT30_SOFTRESET                0x30A2
+
+/******************************************************************************/
+/* Functions Prototypes                                                       */
+/******************************************************************************/
+void SHT30_Update(float *fTemp,  float *fHum);
+
+#endif // SHT30_H_


### PR DESCRIPTION
CN0395 measures indoor air quality by utilizing a Metal Oxide Sensor to
detect gases composed of volatile organic compounds. The sensor is composed
of a heating resistor and a sensing resistor. When the sense resistor is
heated its value changes as a function of the concentrations of different
gasses.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>