### PR TITLE
CN0410: Add support for CN0410 shield

### DIFF
--- a/Arduino Uno R3/examples/CN0410_example/CN0410_example.ino
+++ b/Arduino Uno R3/examples/CN0410_example/CN0410_example.ino
@@ -1,0 +1,121 @@
+#include <Arduino.h>
+#include <SPI.h>
+
+#include "adi_cn0410.h"
+
+char Buffer[12];
+
+uint8_t u8Index;
+bool boCommandReceived = false;
+uint8_t u8Error;
+char u8Channel;
+uint16_t u16DacValue, u16ChannelValue;
+
+CN0410 cn0410;
+
+void setup() {
+
+  Serial.begin(9600);
+
+  cn0410.Init(); //init spi and pins
+
+  cn0410.SendCommand(AD5686_ITERNAL_REFERENCE,
+                     AD5686_DAC_NONE, 0x00); /*enable internal reference*/
+  cn0410.SendCommand(AD5686_POWER,
+                     AD5686_DAC_NONE, 0x00); /*normal power mode for all ch*/
+
+  delay(10); //10 ms delay
+
+  cn0410.SendCommand(AD5686_RESET,
+                     AD5686_DAC_NONE, 0x00); /*soft reset to zero scale*/
+
+  Serial.print(F("\n\n\rCN0410 Demo Software\n\r"));
+  Serial.print(F("Enter command in the following format set_x value,\n\r \
+          where x is the channel (a,b,c) and hit enter \n\r \
+          To reset channels input command set_zero \n\r> "));
+}
+
+void loop() {
+
+  if (boCommandReceived) {
+    boCommandReceived = false; /*reset command received*/
+
+    u8Error = ProcessCommand(&u8Channel, &u16DacValue);
+    
+    if ( u8Error == 0 ) {
+      Serial.print("Command received.\n\r");
+
+      switch ((char)u8Channel) {
+        case 'a':
+          cn0410.SendCommand(AD5686_WRITE_UPDATE,
+                             AD5686_DAC_A, u16DacValue);
+          u16ChannelValue = cn0410.ReadBack(AD5686_DAC_A);
+          Serial.print("Channel A set to: "); Serial.println(u16ChannelValue);
+          break;
+        case 'b':
+          cn0410.SendCommand(AD5686_WRITE_UPDATE,
+                             AD5686_DAC_B, u16DacValue);
+          u16ChannelValue = cn0410.ReadBack(AD5686_DAC_B);
+          Serial.print("Channel B set to: "); Serial.println(u16ChannelValue);
+          break;
+        case 'c':
+          cn0410.SendCommand(AD5686_WRITE_UPDATE,
+                             AD5686_DAC_C, u16DacValue);
+          u16ChannelValue = cn0410.ReadBack(AD5686_DAC_C);
+          Serial.print("Channel C set to: "); Serial.println(u16ChannelValue);
+          break;
+        case '0':
+          cn0410.Reset();
+          Serial.print("All channels reset to 0\n\r");
+          break;
+        default:
+          Serial.print("Invalid value\n\r");
+          break;
+      }
+    } else {
+      Serial.print("Invalid command\n\r");
+    }
+
+    u16ChannelValue = cn0410.ReadBack(AD5686_DAC_A);
+    Serial.print("\n\rChannel A set to: "); Serial.println(u16ChannelValue);
+    u16ChannelValue = cn0410.ReadBack(AD5686_DAC_B);
+    Serial.print("Channel B set to: "); Serial.println(u16ChannelValue);
+    u16ChannelValue = cn0410.ReadBack(AD5686_DAC_C);
+    Serial.print("Channel C set to: "); Serial.println(u16ChannelValue);
+
+    delay(1000); //1 second sleep
+    Serial.print("\n\n\rEnter new command\n\r> ");
+  }
+}
+
+void serialEvent() {
+
+  while (Serial.available() > 0) {
+    Buffer[u8Index] = Serial.read();
+    u8Index++;
+  }
+
+  if ((Buffer[u8Index - 1] == '\n') | (u8Index == 12)) {
+    boCommandReceived = true;
+    u8Index = 0;
+  }
+}
+
+uint8_t ProcessCommand(uint8_t * u8Channel, uint16_t * u16DacValue)
+{
+  uint16_t u16RawValue;
+
+  if ((((char)Buffer[4] != (char)'a') &  ((char)Buffer[4] != (char)'b') &
+       ((char)Buffer[4] != (char)'c') & ((char)Buffer[4] != (char)'z')))
+    return -1;
+
+  if ((Buffer[4] != 'z'))
+    *u8Channel = (char)Buffer[4]; /*channel letter*/
+  else
+    *u8Channel = (char)'0';
+
+  u16RawValue = (uint16_t)atoi((char *)&Buffer[6]);
+  *u16DacValue = u16RawValue;
+
+  return 0;
+}

--- a/Arduino Uno R3/examples/CN0410_example/adi_cn0410.cpp
+++ b/Arduino Uno R3/examples/CN0410_example/adi_cn0410.cpp
@@ -1,0 +1,123 @@
+/***************************************************************************//**
+     @file   adi_cn0410.cpp
+     @brief  Implementation of CN0410 dac interface.
+     @author Mircea Caprioru (mircea.caprioru@analog.com)
+********************************************************************************
+   Copyright 2018(c) Analog Devices, Inc.
+
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    - Neither the name of Analog Devices, Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+    - The use of this software may or may not infringe the patent rights
+      of one or more patent holders.  This license does not release you
+      from the requirement that you obtain separate licenses from these
+      patent holders to use this software.
+    - Use of the software either in source or binary form, must be run
+      on or directly connected to an Analog Devices Inc. component.
+
+   THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+   IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+   CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "adi_cn0410.h"
+
+CN0410::CN0410()
+{
+  /* Constructor for CN0410 */
+}
+
+int8_t CN0410::Init()
+{
+
+  /* Initialize SPI driver */
+  SPI.begin();
+  SPI.setDataMode(SPI_MODE2); //CPHA = 0, CPOL = 1    MODE = 2
+
+  /* Setup LDAC & Reset pins */
+  pinMode(LDAC_PIN, OUTPUT);
+  digitalWrite(LDAC_PIN, LOW);
+  pinMode(RESET_PIN, OUTPUT);
+  digitalWrite(RESET_PIN, HIGH);
+  pinMode(SYNC_PIN, OUTPUT);
+  digitalWrite(SYNC_PIN, HIGH);
+
+  return 0;
+}
+
+void CN0410::Reset()
+{
+  /* Reset all led values */
+  this->SendCommand(AD5686_WRITE_UPDATE, AD5686_DAC_A, 0x00);
+  this->SendCommand(AD5686_WRITE_UPDATE, AD5686_DAC_B, 0x00);
+  this->SendCommand(AD5686_WRITE_UPDATE, AD5686_DAC_C, 0x00);
+  this->SendCommand(AD5686_WRITE_UPDATE, AD5686_DAC_D, 0x00);
+}
+
+void CN0410::UpdateDAC()
+{
+  /* Update the DAC register by pulsing the LDAC pin */
+  digitalWrite(LDAC_PIN, HIGH);
+  digitalWrite(LDAC_PIN, LOW);
+  digitalWrite(LDAC_PIN, HIGH);
+}
+
+int8_t CN0410::SendCommand(uint8_t u8Command,
+                           uint8_t u8Channel, uint16_t u16Value)
+{
+  uint8_t u8Buffer[3];
+
+  u8Buffer[0] = ((u8Command & 0x0F) << 4) + (u8Channel & 0x0F);
+  u8Buffer[1] = u16Value >> 8;
+  u8Buffer[2] = u16Value & 0xFF;
+
+  digitalWrite(SYNC_PIN, LOW);
+
+  SPI.transfer(u8Buffer, 3);
+
+  digitalWrite(SYNC_PIN, HIGH);
+
+  return 0;
+}
+
+uint32_t CN0410::ReadBack(uint8_t u8DacChannelAddr)
+{
+  uint32_t u32ChannelValue;
+  uint8_t rxBuffer[3] = {0, 0, 0};
+  uint8_t txBuffer[3] = {0, 0, 0};
+
+  this->SendCommand(AD5686_SET_READBACK, u8DacChannelAddr, 0x00);
+
+  digitalWrite(SYNC_PIN, LOW);
+
+  for (int i = 0; i < 3; i++)
+    rxBuffer[i] = SPI.transfer(txBuffer[i]);
+
+  digitalWrite(SYNC_PIN, HIGH);
+
+  u32ChannelValue = (rxBuffer[0] << 16) + (rxBuffer[1] << 8) + rxBuffer[2];
+
+  return u32ChannelValue;
+}
+
+CN0410::~CN0410()
+{
+  Serial.println("CN0410 object has been destroyed"); 
+}

--- a/Arduino Uno R3/examples/CN0410_example/adi_cn0410.h
+++ b/Arduino Uno R3/examples/CN0410_example/adi_cn0410.h
@@ -1,0 +1,86 @@
+/***************************************************************************//**
+     @file   adi_cn0410.h
+     @brief  Implementation of CN0410 header.
+     @author Mircea Caprioru (mircea.caprioru@analog.com)
+********************************************************************************
+   Copyright 2018(c) Analog Devices, Inc.
+
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    - Neither the name of Analog Devices, Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+    - The use of this software may or may not infringe the patent rights
+      of one or more patent holders.  This license does not release you
+      from the requirement that you obtain separate licenses from these
+      patent holders to use this software.
+    - Use of the software either in source or binary form, must be run
+      on or directly connected to an Analog Devices Inc. component.
+
+   THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+   IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+   CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <Arduino.h>
+#include <SPI.h>
+
+#ifndef SENSORS_ADI_CN0410_H_
+#define SENSORS_ADI_CN0410_H_
+
+#define SYNC_PIN	10
+#define LDAC_PIN	7
+#define RESET_PIN	6
+
+enum ad5686_commands {
+  AD5686_NO_OPERATION = 0,
+  AD5686_WRITE_LDAC,
+  AD5686_UPDATE,
+  AD5686_WRITE_UPDATE,
+  AD5686_POWER,
+  AD5686_LDAC_MASK,
+  AD5686_RESET,
+  AD5686_ITERNAL_REFERENCE,
+  AD5686_SET_DCEN = 0x08,
+  AD5686_SET_READBACK,
+  AD5686_DAISY_CHAIN = 0x0F
+};
+
+enum ad5686_dac_channels {
+  AD5686_DAC_NONE = 0x00,
+  AD5686_DAC_A = 0x01,
+  AD5686_DAC_B = 0x02,
+  AD5686_DAC_C = 0x04,
+  AD5686_DAC_D = 0x08
+};
+
+class CN0410
+{
+  public:
+    CN0410();
+
+    int8_t Init();
+    void Reset();
+    void UpdateDAC();
+    int8_t SendCommand(uint8_t u8Command, uint8_t u8Channel,
+                       uint16_t u16Value);
+    uint32_t ReadBack(uint8_t u8DacChannelAddr);
+    ~CN0410();
+
+};
+
+#endif /* SENSORS_ADI_CN0410_H_ */


### PR DESCRIPTION
The CN0410 is an Arduino UNO compatible shield that is optimized for smart
agriculture to control current passing through LEDs. It is used with
CFTL-LED bar that has LEDs with specific wavelengths that plants utilize.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>