### PR TITLE
Fix FIFO error in ADXL372 wrapper code

### DIFF
--- a/Arduino Uno R3/examples/ADXL372_example/adxl372.cpp
+++ b/Arduino Uno R3/examples/ADXL372_example/adxl372.cpp
@@ -42,7 +42,7 @@
 //#define ADXL_DEBUG
 
 static int adxl_read_reg_multiple(adxl_spi_handle *spi, unsigned char reg,
-                                  unsigned char count, unsigned char *val)
+                                  unsigned short count, unsigned char *val)
 {
     reg = reg << 1 | ADXL_SPI_RNW;
     return spi_write_then_read(spi, &reg, 1, val, count);   


### PR DESCRIPTION
Because the FIFO on the ADXL372 provides 512 records, the adxl_read_reg_multiple() function must support 16-bit values for count, not just 8-bit.