### PR TITLE
adxl372_example: Fix count size to short

### DIFF
--- a/Arduino Uno R3/examples/ADXL372_example/adxl372.cpp
+++ b/Arduino Uno R3/examples/ADXL372_example/adxl372.cpp
@@ -42,7 +42,7 @@
 //#define ADXL_DEBUG
 
 static int adxl_read_reg_multiple(adxl_spi_handle *spi, unsigned char reg,
-                                  unsigned char count, unsigned char *val)
+                                  unsigned short count, unsigned char *val)
 {
     reg = reg << 1 | ADXL_SPI_RNW;
     return spi_write_then_read(spi, &reg, 1, val, count);   


### PR DESCRIPTION
The FIFO buffer can contain up to 512 samples so the count parameter must
be 16-bit to be able to count to that value.

Fixes: c038c16c8e0c ("Arduino shields examples")
Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>