### PR TITLE
azure-pipelines: fix target branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ pr:
 
 variables:
   runCondition: true
-  targetBranch: $[ variables['Build.SourceBranchName'] ]
+  targetBranch: $[ variables['System.PullRequest.TargetBranchName'] ]
 
 jobs:
 - job: LinuxBuilds


### PR DESCRIPTION
As the variable name states, the target branch should contain information about the branch against which the new commits / pull request are redirected. Currently the variable contains the name of the branch on which the commits are made (source branch). Update the variable value accordingly.