### PR TITLE
Ensure all allowed filter bit combinations can be set on on AD7124.

### DIFF
--- a/Arduino Uno R3/examples/CN0391_example/CN0391.cpp
+++ b/Arduino Uno R3/examples/CN0391_example/CN0391.cpp
@@ -184,9 +184,10 @@ void CN0391_init() {
 
    // Set AD7124_Filter_0 0x21
    regNr = AD7124_Filter_0;
-   setValue = AD7124_ReadDeviceRegister(regNr);
-   setValue |= AD7124_FILT_REG_FILTER(2);                     // set SINC3
-   setValue |= AD7124_FILT_REG_FS(384);                     //FS = 48 => 50 SPS LOW power
+   setValue = 0; // Avoid interference with nonzero Power-On/Reset Value
+   setValue |= AD7124_FILT_REG_FILTER(2);	// set SINC3
+   setValue |= FILT_REG_POST_FILTER(3);		// Keep default POST_FILTER setting	
+   setValue |= AD7124_FILT_REG_FS(384);         //FS = 48 => 50 SPS LOW power
    setValue &= 0xFFFFFF;
    AD7124_WriteDeviceRegister(regNr, setValue);// Write data to _ADC
 
@@ -236,11 +237,12 @@ void CN0391_init() {
    setValue &= 0xFFFF;
    AD7124_WriteDeviceRegister(regNr, setValue);   // Write data to _ADC
 
-   // Set AD7124_Filter_0 0x21
+   // Set AD7124_Filter_1 0x22
    regNr = AD7124_Filter_1;
-   setValue = AD7124_ReadDeviceRegister(regNr);
-   setValue |= AD7124_FILT_REG_FILTER(2);                     // set SINC3
-   setValue |= AD7124_FILT_REG_FS(384);                     //FS = 48 => 50 SPS
+   setValue = 0;				// Avoid interference with nonzero Power-ON/reset Value
+   setValue |= AD7124_FILT_REG_FILTER(2);	// set SINC3
+   setValue |= FILT_REG_POST_FILTER(3);		// Keep default POST_FILTER setting	
+   setValue |= AD7124_FILT_REG_FS(384);		//FS = 48 => 50 SPS
    setValue &= 0xFFFFFF;
    AD7124_WriteDeviceRegister(regNr, setValue);// Write data to _ADC
 


### PR DESCRIPTION
If the parameter of AD7124_FILT_REG_FS() was changed from 384, it was unlikely to be transferred to the AD7124 properly. This made it impossible to change the output data rate of the ADC.

Root cause is that all filter registers have a Power-On/Reset Value of 0x060180, which means that FS is 0x180 (=384) by default.  Instead of replacing the default value by the paramter of AD7124_FILT_REG_FS(), the default value and the paramter were binary anded and the result was written into the FS bits.

Solution is to build up the new register content from 0. It ensures the default POST_FILTER setting is kept if not expilicitly changed. The REJ60 and SINGLE_CYCLE bits stay clear as they are in Power-On/Reset. This is considered okay because this code is intended to initialize the AD7124 after a power-on or reset.