### PR TITLE
CN0429: Add support for CN0429 shield

### DIFF
--- a/Arduino Uno R3/examples/CN0429_example/ADuCM3029_demo_cn0428_cn0429.h
+++ b/Arduino Uno R3/examples/CN0429_example/ADuCM3029_demo_cn0428_cn0429.h
@@ -1,0 +1,54 @@
+/*****************************************************************************
+   GasSensingCFTL.h
+ *****************************************************************************/
+
+#ifndef __GASSENSINGCFTL_H__
+#define __GASSENSINGCFTL_H__
+
+#ifdef __cplusplus
+#define EXTERNC extern "C"
+#else
+#define EXTERNC
+#endif
+
+#include <stdint.h>
+
+#define _CR                      13      /* <ENTER> */
+#define _LF                      10      /* <New line> */
+#define _SPC                     32      /* <Space> */
+#define _BS                      8       /* <Backspace> */
+#define _EOS					 "\0"	 /* <End of String */
+
+//TODO: replace with dynamic device addressing
+#define ADI_CFG_I2C_SENSOR1_ADDR (0x0Au)
+#define ADI_CFG_I2C_SENSOR2_ADDR (0x0Bu)
+#define ADI_CFG_I2C_SENSOR3_ADDR (0x0Cu)
+#define ADI_CFG_I2C_SENSOR4_ADDR (0x0Du)
+
+//Add water quality command for how many bytes to read from slave
+#define BYTES_TO_READ				0x61
+
+typedef enum
+{
+  INIT = 0,
+  COMMAND,
+  STREAM_GAS,
+  OVERRIDE,
+  WATER
+} eFSM_State;
+
+EXTERNC char			cmdInString[64];
+
+/* Ringbuffer structure */
+struct RingBuf {
+  char *rb_head;
+  char *rb_tail;
+  char *rb_write;
+  char *rb_read;
+};
+
+EXTERNC struct RingBuf RX, TX;
+
+EXTERNC eFSM_State FSM_State;
+
+#endif /* __GASSENSINGCFTL_H__ */

--- a/Arduino Uno R3/examples/CN0429_example/CN0429_example.ino
+++ b/Arduino Uno R3/examples/CN0429_example/CN0429_example.ino
@@ -1,0 +1,484 @@
+#include <Arduino.h>
+#include "ADuCM3029_demo_cn0428_cn0429.h"
+#include "adi_m355_gas_sensor.h"
+#include <stdio.h>
+#include <string.h>
+#include "cli.h"
+#include "RingBuffer.h"
+
+using namespace adi_sensor_swpack;
+
+#define ADI_CFG_I2C_DEFAULT_ADDR (0x4Cu)
+
+/* ================================================== */
+/*   SYSTEM VARIABLES - handles, memory, error flags   */
+/* ================================================== */
+int       eSensorResult;
+
+/* ================================================== */
+/*            VARIABLES           */
+/* ================================================== */
+const uint8_t CS_Pin [4] = {7, 6, 5, 4};   // Store Chip Select GPIO Pin address
+const uint8_t INT_Pin [4] = {2, 3, 8, 9}; // Store Interrupt GPIO Pin address
+
+/* Ringbuffer structure */
+struct RingBuf RX, TX;
+
+char       cmdInString[64] = ""; // holds incoming user command
+uint8_t       cmdInCnt = 0;     // counts incoming bytes over UART
+
+M355_GAS      m355_gas_sensor;
+M355_GAS     *pGasSensor = &m355_gas_sensor;
+
+uint8_t Slave_Rx_Index = 0;
+uint8_t initialcycle = 1;
+
+bool S1_detected = false;
+bool S2_detected = false;
+bool S3_detected = false;
+bool S4_detected = false;
+
+eFSM_State FSM_State = INIT;
+
+void flushBuff(uint8_t *buff, uint16_t len) {
+  memset(buff, 0, len);
+}
+
+/*********************************************************************
+
+    Function:       check_string
+
+    Description:    Function looks for string (string_to_search) with
+            length string_len within the ring buffer. If this
+            string is found, function returns Success and
+            deletes this string from ring buffer. Otherwise
+            returns Failure.
+
+*********************************************************************/
+int check_string(uint8_t *string_to_search, uint16_t string_len)
+{
+  uint8_t read_char = 0;
+  uint16_t  match_success = 0, loop = 0;
+
+  // Find first character of search string in read buffer
+  do
+  {
+    read_char = GetChar();
+    loop++;
+  } while ((read_char != string_to_search[0]) && (loop <= MAX_BUFLEN));                  // 35 is the size of the RX buffer, if it's all read out and no match then reset
+
+  if (loop >= MAX_BUFLEN)
+  {
+    return 0;                                                              // no match
+  }
+  else                                                                          // Got a match, check if its as expected
+  {
+    match_success += 1;                                                         // if we got here then there was a match in the first character
+
+    for (loop = 1; loop < string_len; loop++)                                  // Loop through the match string and start at 1 as already found first character
+    {
+      read_char = GetChar();
+      if (read_char == string_to_search[loop])
+      {
+        match_success += 1;
+      }
+    }
+    if (match_success == string_len)                                           // have all chars matched ?
+    {
+      DeleteChar(string_len);                       // delete command from the ring buffer
+      return 1;
+    }
+    else
+    {
+      Empty_Ring();
+      return 0;
+    }
+  }
+}
+
+/* UART Callback handler */
+void serialEvent()
+{
+  char c;
+
+  while (Serial.available() > 0) {
+    cmdInString[cmdInCnt++] = Serial.read();
+    if (cmdInCnt >= 64) {
+      cmdInCnt = 0;
+      cmdReceived = 1;
+      break;
+    } else if (cmdInString[cmdInCnt - 1] == _CR)   //check for carriage return
+    {
+      cmdInString[cmdInCnt - 1] = '\0'; // end of string indicator
+      cmdInCnt = 0;
+      cmdReceived = 1;
+    }
+
+  }
+}
+
+/*!
+   @brief      Initializes gas sensor and slave I2C address
+
+   @details    Called for each site, so the I2C address is set at run-time based on the site
+          the board is plugged into. Slave has a function that sets its I2C address to
+          new_sensor_address only if the /SS GPIO is set low. This function sets the
+          gpios and then calls that function.
+*/
+int SensorInitwithI2CAddr(uint8_t new_sensor_address, uint8_t site)
+{
+  uint8_t i = 0;
+
+  //  Set target site /CS low and all other sites high
+  for (i = 0; i < 4; i++) {
+    if (site == i + 1) {
+      digitalWrite(CS_Pin[i], LOW);       // Set Sensor CS Low if correct site
+    }
+    else {
+      digitalWrite(CS_Pin[i], HIGH);        // Otherwise set Sensor CS High
+    }
+    delay(50);
+  }
+
+  eSensorResult = pGasSensor->SetI2CAddr(new_sensor_address);
+  if (eSensorResult == SENSOR_ERROR_NONE)
+  {
+    Serial.print(F("Gas Sensor in site ")); Serial.print(site);
+    Serial.print(F(" initialized successfully with address ")); Serial.println(new_sensor_address, HEX);
+  }
+  else if (eSensorResult == SENSOR_ERROR_PH) //Used to identify that a water quality probe was found
+  {
+    Serial.print(F("Water Quality Sensor in site ")); Serial.print(site);
+    Serial.print(F(" initialized successfully with address ")); Serial.println(new_sensor_address, HEX);
+  }
+  else
+  {
+    Serial.print(F("Sensor in site ")); Serial.print(site); Serial.print(F(" ")); Serial.print((unsigned int) eSensorResult, HEX);
+    Serial.print(F(" initialization error. Address ")); Serial.println(new_sensor_address, HEX);
+  }
+
+  return eSensorResult;
+}
+
+/*!
+   @brief      Read sensor config
+
+   @details    Reads sensor config of the sensor with address specified in input parameter
+*/
+int GetSensorCfg(uint8_t sensor_address)
+{
+  uint8_t pBuff[8] = {0};
+  int16_t sigVal = 0;
+  uint16_t unsigVal = 0;
+  uint32_t unsiglVal = 0;
+
+  eSensorResult = pGasSensor->openWithAddr(sensor_address);
+  if (eSensorResult != SENSOR_ERROR_NONE) return eSensorResult;
+  delay(5);
+
+  if (sensor_address == 0x0A) Serial.println(F("Config of sensor on site 1:"));
+  if (sensor_address == 0x0B) Serial.println(F("Config of sensor on site 2:"));
+  if (sensor_address == 0x0C) Serial.println(F("Config of sensor on site 3:"));
+  if (sensor_address == 0x0D) Serial.println(F("Config of sensor on site 4:"));
+  delay(5);
+
+  eSensorResult = pGasSensor->ReadSensorBias(&sigVal);
+  if (eSensorResult != SENSOR_ERROR_NONE) return eSensorResult;
+  Serial.print(F("Vbias = "));
+  Serial.print(sigVal, DEC); Serial.println(F(" mV"));
+  delay(5);
+
+  eSensorResult = pGasSensor->ReadSensorSensitivity(&unsiglVal);
+  if (eSensorResult != SENSOR_ERROR_NONE) return eSensorResult;
+  Serial.print(F("Sensitivity = "));
+  Serial.print((float)(unsiglVal / 100.0), 2); Serial.println(F(" nA/ppm"));
+  delay(5);
+
+  eSensorResult = pGasSensor->ReadMeasurementTime(&unsigVal);
+  if (eSensorResult != SENSOR_ERROR_NONE) return eSensorResult;
+  Serial.print(F("Measurement Time = "));
+  Serial.print(unsigVal, DEC); Serial.println(F(" msec"));
+  delay(5);
+
+  delay(5);
+
+  return eSensorResult;
+}
+
+/*!
+   @brief      Reads averaged ppb value from gas sensor
+
+   @details    Reads sensor data utilizing custom gas sensor I2C library and sends this data over UART.
+*/
+int32_t SensorReadoutPPB(uint8_t sensor_address)
+{
+  int32_t PPB_Gas_Reading = 0;
+  eSensorResult = pGasSensor->openWithAddr(sensor_address);
+  eSensorResult = pGasSensor->ReadDataPPB(&PPB_Gas_Reading);
+  delay(10);
+  return PPB_Gas_Reading;
+}
+
+int32_t ExtractCfgVal()
+{
+  char *ret;
+
+  ret = strstr(cmdInString, " ");
+  ret++;
+
+  return strtol(ret, NULL, 10);
+}
+
+uint8_t *int2binString(int32_t a, uint8_t *buff, uint8_t bufSize) {
+  buff += (bufSize - 1);
+
+  for (int i = 31; i >= 0; i--) {
+    *buff-- = (a & 1) + '0';
+
+    a >>= 1;
+  }
+
+  return buff;
+}
+
+double Ieee754ConvertToDouble(uint8_t s[32])
+{
+  double f;
+  int16_t sign, exponent;
+  uint32_t mantissa;
+  int16_t i;
+
+  sign = s[0] - '0';
+
+  exponent = 0;
+  for (i = 1; i <= 8; i++)
+    exponent = exponent * 2 + (s[i] - '0');
+
+  exponent -= 127;
+
+  if (exponent > -127)
+  {
+    mantissa = 1;
+    exponent -= 23;
+  }
+  else
+  {
+    mantissa = 0;
+    exponent = -126;
+    exponent -= 23;
+  }
+
+  for (i = 9; i <= 31; i++)
+    mantissa = mantissa * 2 + (s[i] - '0');
+
+  f = mantissa;
+
+  while (exponent > 0)
+    f *= 2, exponent--;
+
+  while (exponent < 0)
+    f /= 2, exponent++;
+
+  if (sign)
+    f = -f;
+
+  return f;
+}
+
+/* ================================================== */
+/*           State Machine            */
+/* ================================================== */
+void DataDisplayFSM(void)
+{
+  // VT100 Escape cmds
+  /*uint8_t clear_screen[4] = {0x1B, '[', '2', 'J'};
+    uint8_t cursor_home [3] = {0x1B, '[', 'H'};*/
+
+  uint8_t   readChar = 0; // variable holding address of selected sensor
+  uint8_t   cmdResponseBuff[256] = {0}; // buffer holding sensor response to commands
+  uint8_t   tempBuff[40] = {0};     // buffer for EIS results parsing
+  double    EISpartialresult[8] = {0};  // array of partial results (one line) of EIS
+  int32_t   EISpartialDFTresult[8] = {0}; // array of partial results (DFT impedance) of EIS
+  uint32_t  EISresults[192] = {0};    // array of EIS results
+  int16_t   sigVal = 0;   // temporary variable for signed value
+  uint16_t  unsigVal = 0; // temporary variable for unsigned value
+  uint32_t  unsiglVal = 0;  // temporary variable for long unsigned value
+  char    tempChar = 0;   // temporary variable for char
+  bool    exitloop = false;
+
+  uint8_t pulseDuration, pulseAmplitude;  // Pulse test parameters
+
+  uint8_t tempError;
+  uint8_t numbytes;
+  uint8_t cmdLen;
+  uint16_t timeout;
+
+  switch (FSM_State)
+  {
+    case INIT:
+      FSM_State = COMMAND;
+
+      tempError = SensorInitwithI2CAddr(ADI_CFG_I2C_SENSOR1_ADDR, 1);
+      if (tempError == SENSOR_ERROR_NONE) {
+        S1_detected = true;
+      }
+      else if (tempError == SENSOR_ERROR_PH) { //Water Quality Board installed
+        S1_detected = true;
+        FSM_State = WATER;
+      }
+
+      tempError = SensorInitwithI2CAddr(ADI_CFG_I2C_SENSOR2_ADDR, 2);
+      if (tempError == SENSOR_ERROR_NONE) {
+        S2_detected = true;
+      }
+      else if (tempError == SENSOR_ERROR_PH) { //Water Quality Board installed
+        S2_detected = true;
+        FSM_State = WATER;
+      }
+
+      tempError = SensorInitwithI2CAddr(ADI_CFG_I2C_SENSOR3_ADDR, 3);
+      if (tempError == SENSOR_ERROR_NONE) {
+        S3_detected = true;
+      }
+      else if (tempError == SENSOR_ERROR_PH) { //Water Quality Board installed
+        S3_detected = true;
+        FSM_State = WATER;
+      }
+
+      tempError = SensorInitwithI2CAddr(ADI_CFG_I2C_SENSOR4_ADDR, 4);
+      if (tempError == SENSOR_ERROR_NONE) {
+        S4_detected = true;
+      }
+      else if (tempError == SENSOR_ERROR_PH) { //Water Quality Board installed
+        S4_detected = true;
+        FSM_State = WATER;
+      }
+      break;
+
+    case COMMAND:
+      if (check_string((uint8_t *)"PRESENCE_CHECK", 14))
+      {
+        if (S1_detected) Serial.println(F("Sensor detected on site 1"));
+        if (S2_detected) Serial.println(F("Sensor detected on site 2"));
+        if (S3_detected) Serial.println(F("Sensor detected on site 3"));
+        if (S4_detected) Serial.println(F("Sensor detected on site 4"));
+      }
+
+      if (check_string((uint8_t *)"READ_CFGS", 9))
+      {
+        if (S1_detected) GetSensorCfg(ADI_CFG_I2C_SENSOR1_ADDR);
+        delay(10);
+        if (S2_detected) GetSensorCfg(ADI_CFG_I2C_SENSOR2_ADDR);
+        delay(10);
+        if (S3_detected) GetSensorCfg(ADI_CFG_I2C_SENSOR3_ADDR);
+        delay(10);
+        if (S4_detected) GetSensorCfg(ADI_CFG_I2C_SENSOR4_ADDR);
+        delay(10);
+      }
+
+      if (check_string((uint8_t *)"READ_TEMP", 9))
+      {
+        readChar = GetChar(); DeleteChar(1);
+        eSensorResult = pGasSensor->openWithAddr(readChar);
+        eSensorResult = pGasSensor->ReadTemperature(&sigVal);
+        if (eSensorResult != SENSOR_ERROR_NONE) Serial.println(F("ERROR!"));
+        else {
+          Serial.print(F("Temperature = "));
+          Serial.print((float)(sigVal / 100.0), 2); Serial.println(F(" degC"));
+        }
+        pGasSensor->close();
+      }
+
+      if (check_string((uint8_t *)"READ_HUM", 8))
+      {
+        readChar = GetChar(); DeleteChar(1);
+        eSensorResult = pGasSensor->openWithAddr(readChar);
+        eSensorResult = pGasSensor->ReadHumidity(&sigVal);
+        if (eSensorResult != SENSOR_ERROR_NONE) Serial.println(F("ERROR!"));
+        else {
+          Serial.print(F("Humidity = "));
+          Serial.print((float)(sigVal / 100.0), 2); Serial.println(F(" %%RH"));
+        }
+        pGasSensor->close();
+      }
+
+      if (check_string((uint8_t *)"STARTMEAS", 9))
+      {
+        readChar = GetChar(); DeleteChar(1);
+        eSensorResult = pGasSensor->openWithAddr(readChar);
+        eSensorResult = pGasSensor->StartMeasurements();
+        if (eSensorResult != SENSOR_ERROR_NONE) Serial.println(F("ERROR!"));
+        else {
+          Serial.println(F("Measurement started"));
+        }
+        pGasSensor->close();
+      }
+
+      if (check_string((uint8_t *)"STOPMEAS", 8))
+      {
+        readChar = GetChar(); DeleteChar(1);
+        eSensorResult = pGasSensor->openWithAddr(readChar);
+        eSensorResult = pGasSensor->StopMeasurements();
+        if (eSensorResult != SENSOR_ERROR_NONE) Serial.println(F("ERROR!"));
+        else {
+          Serial.println(F("Measurement stopped"));
+        }
+        pGasSensor->close();
+      }
+
+      if (check_string((uint8_t *)"READALLSENSORS", 14))
+      {
+        if (S1_detected) Serial.println(F("Sensor 1[ppb], "));
+        if (S2_detected) Serial.println(F("Sensor 2[ppb], "));
+        if (S3_detected) Serial.println(F("Sensor 3[ppb], "));
+        if (S4_detected) Serial.println(F("Sensor 4[ppb], "));
+        FSM_State = STREAM_GAS;
+      }
+      break;
+
+    case STREAM_GAS:
+      if (S1_detected) {
+        Serial.print(SensorReadoutPPB(ADI_CFG_I2C_SENSOR1_ADDR), DEC); Serial.print(F(" "));
+      }
+      if (S2_detected) {
+        Serial.print(SensorReadoutPPB(ADI_CFG_I2C_SENSOR2_ADDR), DEC); Serial.print(F(" "));
+      }
+      if (S3_detected) {
+        Serial.print(SensorReadoutPPB(ADI_CFG_I2C_SENSOR3_ADDR), DEC); Serial.print(F(" "));
+      }
+      if (S4_detected) {
+        Serial.print(SensorReadoutPPB(ADI_CFG_I2C_SENSOR4_ADDR), DEC); Serial.print(F(" "));
+      }
+      break;
+
+    default:
+      break;
+  }
+}
+
+void setup() {
+  /* Initialize ring buffer */
+  Rb_Init();
+  Serial.begin(9600);
+  Wire.begin();
+
+  for (int i = 0; i < 4; i++)
+    pinMode(CS_Pin[i], OUTPUT);          // sets the digital pin 13 as output
+
+  Serial.println("test1");
+}
+
+void loop() {
+  delay(10);
+  if (cmdReceived && FSM_State != WATER)
+  {
+    CmdProcess();
+    cmdReceived = 0;
+  }
+  if (FSM_State == STREAM_GAS)
+  {
+    delay(1000);
+    DataDisplayFSM();
+  }
+  else DataDisplayFSM();
+}

--- a/Arduino Uno R3/examples/CN0429_example/RingBuffer.cpp
+++ b/Arduino Uno R3/examples/CN0429_example/RingBuffer.cpp
@@ -1,0 +1,95 @@
+//==============================================================================
+//     Module       : ringbuffer.c
+//     Description  : 
+//     Date         : Feb 2016
+//     Version      : Rev 0.00
+//
+//==============================================================================
+#include "Ringbuffer.h"
+
+static char   TXbuf [MAX_BUFLEN];       /* memory for ring buffer #1 (TXD) */
+static char   RXbuf [MAX_BUFLEN];       /* memory for ring buffer #2 (RXD) */
+
+/* define o/p and i/p ring buffer control structures */
+extern  RingBuf_Create(TX);             /* static struct { ... } out; */
+extern  RingBuf_Create(RX);             /* static struct { ... } in; */
+
+/*-----------------------------------------------------------------------------
+* Ring Buffer Init
+*----------------------------------------------------------------------------*/
+void Rb_Init(void)
+{
+ RingBuf_Init(&TX, TXbuf, MAX_BUFLEN-1);               /* set up TX ring buffer */
+ RingBuf_Init(&RX, RXbuf, MAX_BUFLEN-1);               /* set up RX ring buffer */
+}
+
+/*-----------------------------------------------------------------------------
+* PutChar onto Ring buffer
+*----------------------------------------------------------------------------*/
+unsigned char PutChar(char c)
+{
+ if(!RingBuf_Full(&TX))  // si le buffer n'est pas plein, on place l'octet dans le buffer
+ {                 
+  *RingBuf_Putvalue(&TX) = c;                     /* store data in the buffer */
+  RingBuf_Write_Increment(&TX);                   /* adjust write position */
+
+ // Activer la transmission
+ //  	if(!TXactive) {
+ //		TXactive = 1;                      /* indicate ongoing transmission */
+ // 	    TI0 = 1;//   Placer le bit TI à 1 pour provoquer le déclenchement de l'interruption
+ //  	}
+  return 0;  // opération correctement réalisée 
+ }
+ else return 1; // opération échouée
+}
+
+/*-----------------------------------------------------------------------------
+* GetChar from Ring Buffer
+*----------------------------------------------------------------------------*/
+char GetChar(void)
+{
+ char c;
+
+ //if (!RingBuf_Empty(&RX))
+// {                 /* wait for data */
+  c = *RingBuf_Getvalue(&RX);                    /* get character off the buffer */
+  RingBuf_Read_Increment(&RX);                   /* adjust read position */
+  return c;
+ //}
+ //else return 0;
+}
+
+void DeleteChar(int num)
+{
+  for (int i = 0; i < num; i++)
+  {
+    RingBuf_Read_Decrement(&RX);  
+    *RingBuf_Getvalue(&RX) = 0;
+  }
+  for (int i = 0; i < num; i++)
+  {  
+  RingBuf_Read_Increment(&RX); 
+  }
+}
+  
+
+/*-----------------------------------------------------------------------------
+* Empty the Ring Buffer
+*----------------------------------------------------------------------------*/
+void Empty_Ring(void)
+{
+//  for (int i = 0; i < MAX_BUFLEN; i++)
+//  {
+//    RXbuf[i] = 0;
+//  }
+ volatile char c;
+ do{                 
+  c = *RingBuf_Getvalue(&RX);                    /* get character off the buffer */
+  (void)c;										 /* remove unused variable compiler warning */
+  RingBuf_Read_Increment(&RX);                   /* adjust read position */
+ }while(!RingBuf_Empty(&RX));
+}
+
+
+
+

--- a/Arduino Uno R3/examples/CN0429_example/Ringbuffer.h
+++ b/Arduino Uno R3/examples/CN0429_example/Ringbuffer.h
@@ -1,0 +1,71 @@
+//==============================================================================
+//     Module       : ringbuffer.h
+//     Description  : 
+//     Date         : Feb 2016
+//     Version      : Rev 0.00
+//
+//==============================================================================
+#ifndef _ringbuffer_h_
+ #define _ringbuffer_h_
+
+#define MAX_BUFLEN      160
+#define MY_BUF	        160
+
+//void serInit(void);
+unsigned char  PutChar(char c );
+char GetChar ( void); 
+void Rb_Init(void);
+void Empty_Ring(void);
+void DeleteChar(int num);
+
+ #define RingBuf_Create(rb) \
+ struct \
+    { \
+	   char *rb_head; \
+	   char *rb_tail; \
+	   char *rb_write; \
+	   char *rb_read; \
+   }rb 
+   
+ // Initialisation of the ring buffer
+ // rb is the ring buffer
+ // size is the size of the buffer
+ // start is the adress of the buffer
+   
+ #define RingBuf_Init(rb,start,size) \
+    ( \
+		(rb)->rb_write = (rb)->rb_read = (rb)->rb_head = start, \
+        (rb)->rb_tail = &(rb)->rb_head[size] )
+	   
+ // If we reach the end, the pointer should go to the head
+ #define RingBuf_in_Tail(rb,position) ( (position) == (rb)->rb_tail ? (rb)->rb_head:(position) )
+      
+ #define RingBuf_in_Head(rb,position) ( (position) == (rb)->rb_head ? (rb)->rb_tail:(position) )
+	   
+ // Testing if RB is empty 
+ #define RingBuf_Empty(rb) ( (rb)->rb_write==(rb)->rb_read )
+
+ // Testing if RB is full
+// #define RingBuf_Full(rb)  ( RingBuf_in_Tail(rb, (rb)->rb_write+1)==(rb)->rb_read )
+ #define RingBuf_Full(rb)  ( (rb)->rb_write==(rb)->rb_read )     
+
+ // Incrementation of writing pointer
+// #define RingBuf_Write_Increment(rb) ( (rb)->rb_write= RingBuf_in_Tail((rb), (rb)->rb_write+1) )
+ #define RingBuf_Write_Increment(rb)  ( (rb)->rb_write = ((rb)->rb_write == (rb)->rb_tail) ? (rb)->rb_head:(rb)->rb_write+1 )
+ 
+ // Incrémentation of reading pointer
+// #define RingBuf_Read_Increment(rb)  ( (rb)->rb_read= RingBuf_in_Tail((rb), (rb)->rb_read+1) )
+      
+// #define RingBuf_Read_Decrement(rb)  ( (rb)->rb_read= RingBuf_in_Head((rb), (rb)->rb_read-1) )
+
+ #define RingBuf_Read_Increment(rb)  ( (rb)->rb_read = ((rb)->rb_read == (rb)->rb_tail) ? (rb)->rb_head:(rb)->rb_read+1 )
+ #define RingBuf_Read_Decrement(rb)  ( (rb)->rb_read = ((rb)->rb_read == (rb)->rb_head) ? (rb)->rb_tail:(rb)->rb_read-1 )
+     
+     
+ // Putting value in buffer
+ #define RingBuf_Putvalue(rb) ( (rb)->rb_write )
+
+ // Getting value in buffer 
+ #define RingBuf_Getvalue(rb)  ( (rb)->rb_read )
+
+#endif

--- a/Arduino Uno R3/examples/CN0429_example/adi_gas_sensor.h
+++ b/Arduino Uno R3/examples/CN0429_example/adi_gas_sensor.h
@@ -1,0 +1,194 @@
+/*
+ * adi_gas_sensor.h
+ *
+ *  Created on: Sep 4, 2017
+ *      Author: mraninec
+ */
+
+#ifndef ADI_GAS_SENSOR_H_
+#define ADI_GAS_SENSOR_H_
+
+#include "adi_sensor.h"
+#include "adi_m355_gas_sensor_config.h"
+
+namespace adi_sensor_swpack
+{
+    /**
+     * @class Temperature.
+     *
+     * @brief Temperature class abstracts the temperature sesor functionality.
+     *
+     **/
+    class Gas_Reading : public Sensor
+    {
+        public:
+
+            /*!
+             * @brief   Returns temperature.
+            *
+                          * @param [in]  pTemperature Pointer where temperature data is returned.
+            	*
+                          * @param [in]  sizeInBytes  Size of the buffer in bytes. The value depends on the
+            	*              underlying temperature sensor. ADT7420 requires 2-bytes to return
+            	*              the temperature data.
+            	*
+                          * @return   SENSOR_RESULT  In case of success SENSOR_ERROR_NONE is returned. Upon
+                          *           failure applications must use GET_SENSOR_ERROR_TYPE() and
+                          *           GET_DRIVER_ERROR_CODE() to determine the error.
+            	*
+                          * @details  This method is used to return the temperature.
+                          */
+
+            virtual SENSOR_RESULT SensorInit(uint8_t sensor_address) = 0;
+
+            virtual SENSOR_RESULT SetI2CAddr(uint8_t new_I2C_address) = 0;
+
+            virtual SENSOR_RESULT ReadTemperature(int16_t *pSensData) = 0;
+
+			virtual SENSOR_RESULT ReadHumidity(int16_t *pSensData) = 0;
+
+			virtual SENSOR_RESULT SetMeasurementTime(uint16_t pCfgData) = 0;
+
+			virtual SENSOR_RESULT ReadMeasurementTime(uint16_t *pCfgData) = 0;
+
+			virtual SENSOR_RESULT StartMeasurements() = 0;
+
+			virtual SENSOR_RESULT StopMeasurements() = 0;
+
+			virtual SENSOR_RESULT SetTIAGain(uint8_t pCfgData) = 0;
+
+			virtual SENSOR_RESULT ReadTIAGain(uint8_t *pCfgData) = 0;
+
+			virtual SENSOR_RESULT SetSensorBias(int16_t pCfgData) = 0;
+
+			virtual SENSOR_RESULT ReadSensorBias(int16_t *pCfgData) = 0;
+
+			virtual SENSOR_RESULT SetSensorSensitivity(uint32_t pCfgData) = 0;
+
+			virtual SENSOR_RESULT ReadSensorSensitivity(uint32_t *pCfgData) = 0;
+
+			virtual SENSOR_RESULT ConfigureTempComp(uint8_t pCfgData) = 0;
+
+			virtual SENSOR_RESULT ReadTempCompCfg(uint8_t *pCfgData) = 0;
+
+			virtual SENSOR_RESULT RunEISMeasurement() = 0;
+
+			virtual SENSOR_RESULT ReadEISResults(uint8_t *pSensData) = 0;
+
+			virtual SENSOR_RESULT ReadEISResultsFull(uint8_t *pSensData) = 0;
+
+            virtual SENSOR_RESULT Read200RCal(uint8_t *pSensData) = 0;
+
+            virtual SENSOR_RESULT RunPulseTest(uint8_t pulseAmplitude, uint8_t pulseDuration) = 0;
+
+            virtual SENSOR_RESULT ReadPulseTestResults(uint8_t *pSensData, uint8_t pulseAmplitude, uint8_t pulseDuration) = 0;
+
+            virtual SENSOR_RESULT SetRload(uint8_t pCfgData) = 0;
+
+			virtual SENSOR_RESULT ReadRload(uint8_t *pCfgData) = 0;
+
+            virtual SENSOR_RESULT ReadDataPPB(int32_t *pSensData) = 0;
+
+            virtual SENSOR_RESULT ReadDataBits(uint16_t *pSensData) = 0;
+
+            virtual SENSOR_RESULT openWithAddr(uint8_t sensor_address) = 0;
+
+            virtual SENSOR_RESULT I2CReadWrite(uint8_t RW, uint8_t RegAddr, uint8_t *pData, uint16_t size) = 0;
+
+
+
+            /*!
+             * @brief    Opens the temperature sensor and configures it.
+             *
+             * @return   SENSOR_RESULT  In case of success SENSOR_ERROR_NONE is returned. Upon
+             *           failure applications must use GET_SENSOR_ERROR_TYPE() and
+             *           GET_DRIVER_ERROR_CODE() to determine the error.
+             *
+             * @details  Initializes the temperature sensor and configures it. Temperature
+             *           sensors use serial interfaces like SPI or I2C. This function opens the
+             *           underlying peripheral and configures it with the default configuration
+             *           parameters. Default configuration parameters are statically defined in
+             *           the associated sensor class configuration header.For example the
+             *           configuration for ADT7420 is defined in adi_adt7420_cfg.h and the sensor
+             *           software is implemented in adi_adt7420.cpp
+             */
+            virtual SENSOR_RESULT   open() = 0;
+
+            /*!
+             * @brief   Start function puts the temperature sensor in measurement mode.
+             *
+             * @return   SENSOR_RESULT  In case of success SENSOR_ERROR_NONE is returned. Upon
+             *           failure applications must use GET_SENSOR_ERROR_TYPE() and
+             *           GET_DRIVER_ERROR_CODE() to determine the error.
+             *
+             * @details  Start function should be called only after the temperature sensor is
+             *           successfully opened. Start puts the temperature sensor in measurement mode.
+             *           Once in measurement mode temperature sensor's measure acceleration on x,y,z
+             *           axis.
+             */
+            virtual SENSOR_RESULT   start() = 0;
+
+            /*!
+             * @brief    Stops the temperature sensor.
+             *
+             * @return   SENSOR_RESULT  In case of success SENSOR_ERROR_NONE is returned. Upon
+             *           failure applications must use GET_SENSOR_ERROR_TYPE() and
+             *           GET_DRIVER_ERROR_CODE() to determine the error.
+             *
+             * @details  Stop function of an temperature sensor puts the temperature sensor
+            *           in standby
+                          *           mode. With this temperature sensor no longer measures the acceleration.
+                          *           Applications can issue start function to enable measurement mode.
+                          */
+            virtual SENSOR_RESULT   stop() = 0;
+
+            /*!
+             * @brief    Stops the temperature sensor and closes the underlying peripheral
+             *
+             * @return   SENSOR_RESULT  In case of success SENSOR_ERROR_NONE is returned. Upon
+             *           failure applications must use GET_SENSOR_ERROR_TYPE() and
+             *           GET_DRIVER_ERROR_CODE() to determine the error.
+             *
+             * @details  Close function stops the measurements and temperature sensor is kept in
+             *           stanby mode. Underlying peripheral is closed. Applications must use
+             *           open again inorder to enable the measurement mode.
+             */
+            virtual SENSOR_RESULT   close() = 0;
+
+            /* Constructor */
+            Gas_Reading() { }
+
+            /* Destructor */
+            virtual ~Gas_Reading()  { }
+
+            /**
+             * @brief Returns I2C slave address
+            *
+                          * @return i2c slave address
+            	*
+                          * @details This method returns i2c slave address
+                          */
+            uint8_t getSlaveAddress()
+            {
+                return m_slave_addr;
+            }
+
+            /**
+             * @brief  sets the i2c slave address
+            *
+                          * @param  slaveAddr i2c slave address
+            	*
+                          * @details This method is used to set the i2c slave address
+                          */
+            void    setSlaveAddress(const uint8_t slaveAddr)
+            {
+                m_slave_addr = slaveAddr;
+            }
+
+        protected:
+
+            uint8_t m_slave_addr;
+    };
+}
+
+#endif /* ADI_GAS_SENSOR_H_ */

--- a/Arduino Uno R3/examples/CN0429_example/adi_m355_gas_sensor.cpp
+++ b/Arduino Uno R3/examples/CN0429_example/adi_m355_gas_sensor.cpp
@@ -1,0 +1,747 @@
+/*
+   adi_m355_gas_sensor.cpp
+
+    Created on: Sep 4, 2017
+        Author: mraninec
+*/
+
+#include "adi_m355_gas_sensor.h"
+#include "adi_m355_gas_sensor_config.h"
+#include "adi_sensor_errors.h"
+#include "ADuCM3029_demo_cn0428_cn0429.h"
+
+namespace adi_sensor_swpack
+{
+
+/*
+   Open M355 gas sensor
+*/
+SENSOR_RESULT M355_GAS::open()
+{
+  //pADI_GPIO0->DS |= (1 << 4) | (1 << 5);
+  this->m_i2c_address = ADI_CFG_I2C_DEFAULT_ADDR;
+  return (this->InitI2C());
+}
+
+/*
+   Open M355 gas sensor with selected address
+*/
+SENSOR_RESULT M355_GAS::openWithAddr(uint8_t sensor_address)
+{
+  //pADI_GPIO0->DS |= (1 << 4) | (1 << 5);
+  this->m_i2c_address = sensor_address;
+  return (this->InitI2C());
+}
+/*
+   Starts measurement
+*/
+SENSOR_RESULT   M355_GAS::start()
+{
+  return (SENSOR_ERROR_NONE);
+}
+
+/*
+   Stops measurement
+*/
+SENSOR_RESULT   M355_GAS::stop()
+{
+  return (SENSOR_ERROR_NONE);
+}
+
+/*
+   Close device
+*/
+SENSOR_RESULT   M355_GAS::close()
+{
+  return SENSOR_ERROR_NONE;
+}
+
+/**
+   @brief  Returns the temperature value
+
+   @return SENSOR_RESULT
+
+   @details
+*/
+SENSOR_RESULT M355_GAS::InitI2C()
+{
+  return SENSOR_ERROR_NONE;
+}
+
+
+/**
+   @brief  reads or writes data to/from the gas sensor
+
+   @param  void
+
+   @return returns result of I2C communication
+
+   @details
+*/
+SENSOR_RESULT M355_GAS::I2CReadWrite(uint8_t RW, uint8_t RegAddr, uint8_t *pData, uint16_t size)
+{
+  uint8_t i = 0;
+
+  if (RW == READ) {
+    i = 0;
+    Wire.beginTransmission(this->m_i2c_address);
+    Wire.write(RegAddr);
+    Wire.endTransmission(); 
+
+    Wire.requestFrom(this->m_i2c_address, size);
+    while(Wire.available())
+      pData[i++] = Wire.read();    
+
+    
+  } else if (RW == WRITE) {
+    Wire.beginTransmission(this->m_i2c_address);
+    Wire.write(RegAddr);
+    for (i = 0; i < size; i++)
+      Wire.write(pData[i]);
+    Wire.endTransmission();
+    i = 0;
+  }
+
+  return SENSOR_ERROR_NONE;
+}
+
+/**
+   @brief  initializes the sensor - requesting sensor status
+  			until 0x01 response received (IDLE)
+
+   @param  uint8_t sensor_address
+
+   @return returns result of I2C communication
+
+   @details
+*/
+SENSOR_RESULT M355_GAS::SensorInit(uint8_t sensor_address)
+{
+  uint8_t pBuff[2] = {0};
+  uint16_t timeout = 20;
+  SENSOR_RESULT Result = this->openWithAddr(sensor_address);
+
+  do {
+    Result = this->I2CReadWrite(READ, GET_STATUS, &pBuff[0], 1u);
+    delay(100);
+    timeout--;
+  } while ((pBuff[0] != 0x01) && (timeout > 0));
+
+  if (timeout == 0) return SENSOR_ERROR_I2C;
+
+  return Result;
+}
+
+/**
+   @brief Arbitrate address collisions using GPIOs to send a new address to slave if GPIO (SS) is low.
+  			All slaves can start with ADI_CFG_I2C_DEFAULT_ADDR, then call this function to set new address
+  			for given site.
+
+   @param uint8_t new_I2C_address
+
+   @return returns result of I2C communication
+
+   @details
+*/
+SENSOR_RESULT M355_GAS::SetI2CAddr(uint8_t new_I2C_address)
+{
+  uint8_t *pBuff;
+  uint16_t timeout = 20;
+  SENSOR_RESULT Result;
+  pBuff = &new_I2C_address;
+
+  /*===============Ensure this code runs on the driver before SetI2CAddr is called ===========================
+  	//	Set target site /CS low and all other sites high
+  	for(uint8_t i = 0; i<4; i++){
+  		if(site == i + 1){
+  			eGpioResult = adi_gpio_SetLow(CS_Port[i], CS_Pin[i]);				// Set Sensor CS Low if correct site
+  		}
+  		else{
+  			eGpioResult = adi_gpio_SetHigh(CS_Port[i], CS_Pin[i]);				// Otherwise set Sensor CS High
+  		}
+  		delay(50);
+  	}
+    =======================================================================================================   */
+  //Send command to change I2C address
+  Result = this->open(); //uses default address
+  delay(50);
+
+  this->I2CReadWrite(WRITE, SET_I2C_ADDRESS, pBuff, 1);
+  Result = this->close();
+
+  delay(1000); //wait for slave to change its address
+
+  Result = this->openWithAddr(new_I2C_address); //Query new address
+  *pBuff = 0; //set variable at pBuff to 0
+
+  do {
+    Result = this->I2CReadWrite(READ, GET_STATUS, pBuff, 1);
+    delay(100);
+    timeout--;
+  } while ((*pBuff == 0) && (timeout > 0));
+
+  Serial.print("Status is "); Serial.println(*pBuff);
+
+  if (timeout == 0) return SENSOR_ERROR_I2C;
+  if (*pBuff == 3) return SENSOR_ERROR_PH; //Communicate that we found a Water Quality Probe
+
+  return Result;
+}
+
+/**
+   @brief  	Read temperature
+
+   @param  	int16_t *pSensData
+
+   @return 	returns result of I2C communication
+
+   @details This command provides temperature information in signed 16bit format which is used
+   		for sensor temperature compensation. The data is transmitted in integer format * 100:
+   		For example, 	0x09E4 =>    2532 / 100 => 	+25.32�C
+   						0xFB50 => 	-1200 / 100 =>  -12�C
+*/
+SENSOR_RESULT M355_GAS::ReadTemperature(int16_t *pSensData)
+{
+  uint8_t pBuff[2] = {0};
+  int16_t val = 0;
+
+  SENSOR_RESULT Result = this->I2CReadWrite(READ, READ_TEMPERATURE, pBuff, 2);
+  delay(50);
+  Result = this->I2CReadWrite(READ, READ_TEMPERATURE, pBuff, 2);
+
+  val = (pBuff[0] << 8) | pBuff[1];
+  *pSensData = val;
+
+  return Result;
+}
+
+/**
+   @brief  	Read humidity
+
+   @param  	int16_t *pSensData
+
+   @return 	returns result of I2C communication
+
+   @details This command provides humidity information in signed 16bit format.
+  			The data is transmitted in integer format * 100:
+   		For example, 	0x0E10 =>   3600 /100 => +36%
+*/
+SENSOR_RESULT M355_GAS::ReadHumidity(int16_t *pSensData)
+{
+  uint8_t pBuff[2] = {0};
+  int16_t val = 0;
+
+  SENSOR_RESULT Result = this->I2CReadWrite(READ, READ_HUMIDITY, pBuff, 2);
+  delay(50);
+  Result = this->I2CReadWrite(READ, READ_HUMIDITY, pBuff, 2);
+
+  val = (pBuff[0] << 8) | pBuff[1];
+  *pSensData = val;
+
+  return Result;
+}
+
+/**
+   @brief  	Set measurement time(ms)
+
+   @param  	uint16_t pCfgData
+
+   @return 	returns result of I2C communication
+
+   @details This write command programs the ADC Sensor sampling time with an interval
+  			resolution of 1ms / LSB. Default is 500ms (or 0x01F4). The ADC then performs
+  			an average of 10 2.2ms samples at this interval.
+*/
+SENSOR_RESULT M355_GAS::SetMeasurementTime(uint16_t pCfgData)
+{
+  uint8_t pBuff[2] = {0};
+  pBuff[0] = (uint8_t)(pCfgData >> 8);
+  pBuff[1] = (uint8_t)(pCfgData & 0xFF);
+  SENSOR_RESULT Result = this->I2CReadWrite(WRITE, SET_MEAS_TIME_MS, pBuff, 2);
+  delayMicroseconds(500);
+
+  return Result;
+}
+
+/**
+   @brief  	Read measurement time(ms)
+
+   @param  	int16_t *pCfgData
+
+   @return 	returns result of I2C communication
+
+   @details This command reads the ADC Sensor sampling time with an interval
+  			resolution of 1ms / LSB.
+*/
+SENSOR_RESULT M355_GAS::ReadMeasurementTime(uint16_t *pCfgData)
+{
+  uint8_t pBuff[2] = {0};
+  int16_t val = 0;
+  SENSOR_RESULT Result = this->I2CReadWrite(READ, READ_MEAS_TIME_MS, pBuff, 2u);
+  delay(50);
+  Result = this->I2CReadWrite(READ, READ_MEAS_TIME_MS, pBuff, 2u);
+  if (pBuff[0] & 0x80) val = 0xff;
+  val = (val << 8) | pBuff[0];
+  val = (val << 8) | pBuff[1];
+
+  *pCfgData = val;
+
+  return Result;
+}
+
+/**
+   @brief  	Start measurements
+
+   @param  	none
+
+   @return 	returns result of I2C communication
+
+   @details This command tells the ADuCM355 to start ADC sampling the sensor at the sampling
+   		interval set in the "Set Measurement Time" command. Note that this is already set
+   		on programming and is set to 500ms.
+*/
+SENSOR_RESULT M355_GAS::StartMeasurements()
+{
+  uint8_t dummy = 0xFF;
+  SENSOR_RESULT Result = this->I2CReadWrite(WRITE, START_MEASUREMENTS, &dummy, 1);
+  delayMicroseconds(500);
+
+  return Result;
+}
+
+/**
+   @brief  	Stop measurements
+
+   @param  	none
+
+   @return 	returns result of I2C communication
+
+   @details This command tells the ADuCM355 to stop ADC sampling the sensor. The sensor will
+  			still be biased and powered.
+*/
+SENSOR_RESULT M355_GAS::StopMeasurements()
+{
+  uint8_t dummy = 0xFF;
+  SENSOR_RESULT Result = this->I2CReadWrite(WRITE, STOP_MEASUREMENTS, &dummy, 1);
+  delayMicroseconds(500);
+
+  return Result;
+}
+
+/**
+   @brief  	Set TIA gain
+
+   @param  	uint8_t pCfgData
+
+   @return 	returns result of I2C communication
+
+   @details Programs the TIA with the requested gain resistor as instructed by the first data byte.
+			For example, data byte 1 from the Master contains 0x0B. This equates to a 20k resistor.
+*/
+SENSOR_RESULT M355_GAS::SetTIAGain(uint8_t pCfgData)
+{
+  SENSOR_RESULT Result = this->I2CReadWrite(WRITE, SET_TIA_GAIN, &pCfgData, 1);
+  delayMicroseconds(500);
+
+  return Result;
+}
+
+/**
+   @brief  	Read TIA gain
+
+   @param  	uint8_t *pCfgData
+
+   @return 	returns result of I2C communication
+
+   @details Reads the current TIA gain resistor selected and populates the first data byte with its
+  			reference value. This needs to be indexed to the eGainResistor enum.
+  			For example, data byte 1 from the M355 contains 0x11. This equates to a 64k resistor.
+*/
+SENSOR_RESULT M355_GAS::ReadTIAGain(uint8_t *pCfgData)
+{
+  SENSOR_RESULT Result = this->I2CReadWrite(READ, READ_TIA_GAIN, pCfgData, 1u);
+  delay(50);
+  Result = this->I2CReadWrite(READ, READ_TIA_GAIN, pCfgData, 1u);
+
+  return Result;
+}
+
+/**
+   @brief  	Set sensor bias voltage
+
+   @param  	int16_t pCfgData
+
+   @return 	returns result of I2C communication
+
+   @details This write command takes 2 bytes representing a mV Bias voltage. It is a signed 16bit value
+  			so negative values can be used as some sensors require a negative bias. The first byte
+  			transmitted is the upper byte then followed by the lower. So 100mV Bias setting would be
+  			transmitted as the command 0x10 followed by two data bytes, 0x00 and then 0x64.
+  			For example, 100mV is represented by 0x64 and -100mV is 0xFF9C.
+  			This is a volatile setting and is reverted to the default sensor setting on a reset.
+*/
+SENSOR_RESULT M355_GAS::SetSensorBias(int16_t pCfgData)
+{
+  uint8_t pBuff[2] = {0};
+  pBuff[0] = (uint8_t)(pCfgData >> 8);
+  pBuff[1] = (uint8_t)(pCfgData & 0xFF);
+  SENSOR_RESULT Result = this->I2CReadWrite(WRITE, SET_VBIAS, pBuff, 2);
+  delayMicroseconds(500);
+
+  return Result;
+}
+
+/**
+   @brief  	Read sensor bias voltage
+
+   @param  	int16_t *pCfgData
+
+   @return 	returns result of I2C communication
+
+   @details Reads the current mV Bias value as two 8bit values which represent a 16bit signed number.
+  			For example if the bytes returned are 0xFF, 0xEC, this represents 0xFFEC which is -20mV bias.
+*/
+SENSOR_RESULT M355_GAS::ReadSensorBias(int16_t *pCfgData)
+{
+  uint8_t pBuff[2] = {0};
+  int16_t val = 0;
+  SENSOR_RESULT Result = this->I2CReadWrite(READ, READ_VBIAS, pBuff, 2u);
+  delay(50);
+  Result = this->I2CReadWrite(READ, READ_VBIAS, pBuff, 2u);
+  if (pBuff[0] & 0x80) val = 0xff;
+  val = (val << 8) | pBuff[0];
+  val = (val << 8) | pBuff[1];
+
+  *pCfgData = val;
+
+  return Result;
+}
+
+/**
+   @brief  	Set sensor sensitivity (nA/ppm)
+
+   @param  	uint32_t pCfgData
+
+   @return 	returns result of I2C communication
+
+   @details Configures the sensitivity nA/ppm settings of each sensor board is important for best
+  			performance as each EC sensor is unique. Many sensors have a label on them indicating
+  			its response, and this value needs to be inputed into the gas sensor daughter board
+  			so the ADuCM355 can use it to determine ppb calculations. When programming the sensor
+  			sensitivity, read the label nA/ppm and multiply by 100 to shift up two decimal points:
+  			For example a 7.53nA/ppm sensor simply becomes 753. Load this value across a 3byte command
+  			to the M355. The firmware on the M355 captures this command and divides back
+  			by 100 for nA/ppm then.
+*/
+SENSOR_RESULT M355_GAS::SetSensorSensitivity(uint32_t pCfgData)
+{
+  uint8_t pBuff[3] = {0};
+  pBuff[0] = (uint8_t)(pCfgData >> 16);
+  pBuff[1] = (uint8_t)(pCfgData >> 8);
+  pBuff[2] = (uint8_t)(pCfgData & 0xFF);
+  SENSOR_RESULT Result = this->I2CReadWrite(WRITE, SET_SENSOR_SENS, pBuff, 3u);
+  delayMicroseconds(500);
+
+  return Result;
+}
+
+/**
+   @brief  	Read sensor sensitivity (nA/ppm)
+
+   @param  	int32_t *pCfgData
+
+   @return 	returns result of I2C communication
+
+   @details Reads a number in the first data byte indicating the current sensor that the M355 daughter board has
+  			initialized and configured. The format is as per the "Set Sensor Type" command
+*/
+SENSOR_RESULT M355_GAS::ReadSensorSensitivity(uint32_t *pCfgData)
+{
+  uint8_t pBuff[3] = {0};
+  uint32_t val = 0;
+  SENSOR_RESULT Result = this->I2CReadWrite(READ, READ_SENSOR_SENS, pBuff, 3u);
+  delay(50);
+  Result = this->I2CReadWrite(READ, READ_SENSOR_SENS, pBuff, 3u);
+
+  val = ((pBuff[0] << 16) | (pBuff[1] << 8) | pBuff[2]);
+  *pCfgData = val;
+
+  return Result;
+}
+
+/**
+   @brief  	Configure Temperature Compensation
+
+   @param  	uint8_t pCfgData
+
+   @return 	returns result of I2C communication
+
+   @details This command enables temperature compensation on the active sensor. Write the first data
+  			byte as 0x00 to turn off or 0x01 to turn on. Note that regular temperature updates should
+  			be provided to the M355 AQS board for this feature to work optimally and it operates for
+  			ppb calculated data only (not LSB data yet).
+*/
+SENSOR_RESULT M355_GAS::ConfigureTempComp(uint8_t pCfgData)
+{
+  SENSOR_RESULT Result = this->I2CReadWrite(WRITE, SET_TEMP_COMP, &pCfgData, 1);
+  delayMicroseconds(500);
+
+  return Result;
+}
+
+/**
+   @brief  	Read Temperature Compensation settings
+
+   @param  	uint8_t *pCfgData
+
+   @return 	returns result of I2C communication
+
+   @details This command reads the Temperature Compensation status in the first data byte.
+  			0x00 == Off
+  			0x01 == On.
+*/
+SENSOR_RESULT M355_GAS::ReadTempCompCfg(uint8_t *pCfgData)
+{
+  SENSOR_RESULT Result = this->I2CReadWrite(READ, READ_TEMP_COMP, pCfgData, 1u);
+  delay(50);
+  Result = this->I2CReadWrite(READ, READ_TEMP_COMP, pCfgData, 1u);
+
+  return Result;
+}
+
+/**
+   @brief  	Run EIS measurement
+
+   @param  	none
+
+   @return 	returns result of I2C communication
+
+   @details This command instructs the M355 to perform an impedance spectroscopy measurement using
+  			the following frequencies:
+  			1kHz, 5kHz, 10kHz, 20kHz, 30kHz, 40kHz, 50kHz, 60kHz, 70kHz, 90kHz, 160kHz and 200kHz.
+  			Results are read back with the Read EIS Results command in 4 hex byte format.
+*/
+SENSOR_RESULT M355_GAS::RunEISMeasurement()
+{
+  uint8_t dummy = 0x01;
+  SENSOR_RESULT Result = this->I2CReadWrite(WRITE, RUN_EIS, &dummy, 1);
+  delayMicroseconds(500);
+
+  return Result;
+}
+
+/**
+   @brief  	Read EIS results
+
+   @param  	uint8_t *pSensData
+
+   @return 	returns result of I2C communication
+
+   @details This write command instructs the M355 AQS board to begin returning EIS data representing
+  			Frequency, Magnitude and Phase when the next read command is issued. Continue reading
+  			until 0xFF is read continuously. Normally 144 bytes are expected. This consists of 12bytes
+  			for the 12 frequencies (as detailed in the Run EIS command). Frequency, Magnitude and Phase
+  			are 4 bytes each. So 12 bytes for 12 frequency points = 144bytes. The data returned is in
+  			byte array format representing IEEE754 single precision 32bit floating point data.
+*/
+SENSOR_RESULT M355_GAS::ReadEISResults(uint8_t *pSensData)
+{
+  SENSOR_RESULT Result = this->I2CReadWrite(READ, READ_EIS_RESULTS, pSensData, 144u);
+  delay(100);
+
+  Result = this->I2CReadWrite(READ, READ_EIS_RESULTS, pSensData, 144u);
+
+  return Result;
+}
+
+/**
+   @brief  	Read EIS results
+
+   @param  	uint8_t *pSensData
+
+   @return 	returns result of I2C communication
+
+   @details This write command instructs the M355 AQS board to begin returning EIS data representing
+  			DFT Impedance and Magnitude, Bode Magnitude, Bode Phase, RLoadMagnitude and Capacity when
+  			the next read command is issued. Continue reading until 0xFF is read continuously. Normally
+  			720 bytes are expected. This consists of 60 bytes for the 12 frequencies (as detailed in
+  			the Run EIS command). Every value is 4 bytes each.
+  			So 60 bytes for 12 frequency points = 720 bytes. The data returned is in
+  			byte array format representing IEEE754 single precision 32bit floating point data.
+*/
+SENSOR_RESULT M355_GAS::ReadEISResultsFull(uint8_t *pSensData)
+{
+  SENSOR_RESULT Result = this->I2CReadWrite(READ, READ_EIS_RESULTS_FULL, pSensData, 1000u);
+  delay(150);
+
+  Result = this->I2CReadWrite(READ, READ_EIS_RESULTS_FULL, pSensData, 1000u);
+
+  return Result;
+}
+
+/**
+   @brief  	Read 200R RTIA resistor
+
+   @param  	uint8_t *pSensData
+
+   @return 	returns result of I2C communication
+
+   @details As part of the initial calibration of the ADuCM355 AFE, the 200R RTIA is calibrated
+   		using the internal DAC and external reference resistor. This resistance needs to be
+   		used to obtain correct uA levels when converting the 16bit ADC results from the pulse
+   		test to current using the formula
+*/
+SENSOR_RESULT M355_GAS::Read200RCal(uint8_t *pSensData)
+{
+  SENSOR_RESULT Result = this->I2CReadWrite(READ, READ_200R_RTIA_CAL_RESULT, pSensData, 1);
+  delay(50);
+  Result = this->I2CReadWrite(READ, READ_200R_RTIA_CAL_RESULT, pSensData, 1);
+
+  return Result;
+}
+
+/**
+   @brief  	Performs Pulse Test
+
+   @param  	uint8_t pulseAmplitude - Amplitude of the pulse in mV (typically 1mV)
+  			uint8_t pulseDuration  - Duration of the pulse (keep <200 ms)
+
+   @return 	returns result of I2C communication
+
+   @details	Pulse tests can be used for sensor diagnostics to determine sensor
+  			state of health and lifetime. Results are stored in SRAM and will
+  			need to be read by the i2C Master device.
+*/
+SENSOR_RESULT M355_GAS::RunPulseTest(uint8_t pulseAmplitude, uint8_t pulseDuration)
+{
+  uint8_t data[2] = {0};
+  if (pulseAmplitude < 1 || pulseAmplitude > 3) pulseAmplitude = 1;
+  if (pulseDuration < 10 || pulseDuration > 200) pulseDuration = 100;
+  data[0] = pulseAmplitude;
+  data[1] = pulseDuration;
+  SENSOR_RESULT Result = this->I2CReadWrite(WRITE, RUN_PULSE_TEST, data, 2u);
+  delayMicroseconds(500);
+  return Result;
+}
+
+/**
+   @brief  	Reads Pulse Test Results
+
+   @param  	uint16_t *pSensData
+
+  			----- variables below MUST have the same value as above !! -----
+  			uint8_t pulseAmplitude - Amplitude of the pulse in mV (typically 1mV)
+  			uint8_t pulseDuration  - Duration of the pulse (keep <200 ms)
+
+   @return 	returns result of I2C communication
+
+   @details	Pulse tests can be used for sensor diagnostics to determine sensor
+  			state of health and lifetime. Results are stored in SRAM and will
+  			need to be read by the i2C Master device.
+*/
+SENSOR_RESULT M355_GAS::ReadPulseTestResults(uint8_t *pSensData, uint8_t pulseAmplitude, uint8_t pulseDuration)
+{
+  uint16_t intToRead = (((pulseDuration + 10) * 1000) / 110) * 2;	// added 5 ms sampling before and after the test, 110 us ADC sample time
+
+  SENSOR_RESULT Result = this->I2CReadWrite(READ, READ_PULSE_TEST_RESULTS, &pSensData[0], intToRead);
+  delay(150);
+
+  Result = this->I2CReadWrite(READ, READ_PULSE_TEST_RESULTS, &pSensData[0], intToRead);
+
+  return Result;
+}
+
+/**
+   @brief  	Set Rload resistor
+
+   @param  	uint8_t pCfgData
+
+   @return 	returns result of I2C communication
+
+   @details This command programs the selected sensor load resistor. This resistor is in series
+  			with the working electrode and is usually specified by the sensor manufacturer.
+			It is a 1 byte command with the value of 0 to 7 being allowed.
+*/
+SENSOR_RESULT M355_GAS::SetRload(uint8_t pCfgData)
+{
+  SENSOR_RESULT Result = this->I2CReadWrite(WRITE, SET_RLOAD, &pCfgData, 1);
+  delayMicroseconds(500);
+
+  return Result;
+}
+
+/**
+   @brief  	Read Rload resistor
+
+   @param  	uint8_t *pCfgData
+
+   @return 	returns result of I2C communication
+
+   @details This command reads the currently selected sensor load resistor. This resistor is in
+  			series with the working electrode and is usually specified by the sensor manufacturer.
+			It is a 1 byte command with the value of 0 to 7 being allowed.
+*/
+SENSOR_RESULT M355_GAS::ReadRload(uint8_t *pCfgData)
+{
+  SENSOR_RESULT Result = this->I2CReadWrite(READ, READ_RLOAD, pCfgData, 1u);
+  delay(50);
+  Result = this->I2CReadWrite(READ, READ_RLOAD, pCfgData, 1u);
+
+  return Result;
+}
+
+/**
+   @brief  	Read sensor data as PPB value
+
+   @param  	uint32_t *pSensData
+
+   @return 	returns result of I2C communication
+
+   @details	Instructs the M355 AQS board to begin delivering averaged 24bit ppb data when the next
+  			read command is issued. Default is a 30sec average of data.
+*/
+SENSOR_RESULT M355_GAS::ReadDataPPB(int32_t *pSensData)
+{
+  uint8_t pBuff[3] = {0};
+  int32_t val = 0;
+  int32_t temp = -500000;
+  SENSOR_RESULT Result = this->I2CReadWrite(READ, READ_AVG_PPB, pBuff, 3);
+  delay(50);
+  Result = this->I2CReadWrite(READ, READ_AVG_PPB, pBuff, 3);
+  val = 	(
+            (pBuff[0] << 24)
+            | (pBuff[1] << 16)
+            | (pBuff[2] << 8)
+          ) >> 8;
+
+  *pSensData = val;
+  if (val < temp)
+  {
+    delay(1);
+  }
+  return Result;
+}
+
+/**
+   @brief  	Read sensor data as bits
+
+   @param  	uint16_t *pSensData
+
+   @return 	returns result of I2C communication
+
+   @details Instructs the M355 AQS board to begin delivering averaged 16bit LSB data when the next
+  			read command is issued. Default is a 30sec average of data.
+*/
+SENSOR_RESULT M355_GAS::ReadDataBits(uint16_t *pSensData)
+{
+  uint8_t pBuff[2] = {0};
+  SENSOR_RESULT Result = this->I2CReadWrite(READ, READ_AVG_LSB, pBuff, 2);
+  delay(50);
+  Result = this->I2CReadWrite(READ, READ_AVG_LSB, pBuff, 2);
+
+  *pSensData = (pBuff[0] << 8) | pBuff[1];
+
+  return Result;
+}
+
+}

--- a/Arduino Uno R3/examples/CN0429_example/adi_m355_gas_sensor.h
+++ b/Arduino Uno R3/examples/CN0429_example/adi_m355_gas_sensor.h
@@ -1,0 +1,126 @@
+/*
+   adi_m355_gas_sensor.h
+
+    Created on: Sep 4, 2017
+        Author: mraninec
+*/
+
+#ifndef ADI_M355_GAS_SENSOR_H_
+#define ADI_M355_GAS_SENSOR_H_
+
+#include "adi_gas_sensor.h"
+#include "adi_m355_gas_sensor_config.h"
+#include <Wire.h>
+#include <Arduino.h>
+
+#define	GET_STATUS              	0x02
+#define SET_TEMPERATURE         	0x03
+#define READ_TEMPERATURE        	0x04
+#define SET_HUMIDITY            	0x05
+#define	READ_HUMIDITY           	0x06
+#define SET_MEAS_TIME_MS        	0x07
+#define READ_MEAS_TIME_MS			0x53
+#define START_MEASUREMENTS      	0x08
+#define STOP_MEASUREMENTS       	0x0A
+#define SET_TIA_GAIN            	0x0C
+#define READ_TIA_GAIN           	0x0E
+#define SET_VBIAS		        	0x10
+#define READ_VBIAS			       	0x12
+#define SET_VZERO_VOLTAGE       	0x14
+#define READ_VZERO_VOLTAGE      	0x16
+#define SET_SENSOR_TYPE         	0x18
+#define SET_SENSOR_SENS         	0x19
+#define READ_SENSOR_TYPE        	0x1A
+#define READ_SENSOR_SENS        	0x1B
+#define	SET_TEMP_COMP           	0x1C
+#define READ_TEMP_COMP          	0x1D
+#define RUN_EIS						0x1E
+#define READ_EIS_RESULTS			0x1F
+#define READ_AVG_LSB            	0x20
+#define READ_EIS_RESULTS_FULL		0x25
+#define READ_RAW_LSB            	0x26
+#define READ_AVG_PPB            	0x30
+#define READ_RAW_PPB            	0x40
+#define RUN_PULSE_TEST          	0x45
+#define READ_PULSE_TEST_RESULTS 	0x50
+#define SET_RLOAD					0x51
+#define READ_RLOAD					0x52
+#define READ_200R_RTIA_CAL_RESULT 	0x55
+#define SET_I2C_ADDRESS				0x80
+
+typedef enum {
+  READ = 0,
+  WRITE
+} eI2C_DIR;
+
+namespace adi_sensor_swpack
+{
+/**
+   @class ADT7420 Temperature Class
+
+   @brief ADT7420 temperature class interface.
+
+ **/
+class M355_GAS : public Gas_Reading
+{
+  public:
+    /*!< Pure virtual functions must be implemented by the derived class */
+
+    virtual SENSOR_RESULT open();
+    virtual SENSOR_RESULT start();
+    virtual SENSOR_RESULT stop();
+    virtual SENSOR_RESULT close();
+
+    virtual SENSOR_RESULT openWithAddr(uint8_t sensor_address);
+    virtual SENSOR_RESULT I2CReadWrite(uint8_t RW, uint8_t RegAddr, uint8_t *pData, uint16_t size);
+    virtual SENSOR_RESULT SensorInit(uint8_t sensor_address);
+    virtual SENSOR_RESULT SetI2CAddr(uint8_t new_I2C_address);
+    virtual SENSOR_RESULT ReadTemperature(int16_t *pSensData);
+    virtual SENSOR_RESULT ReadHumidity(int16_t *pSensData);
+    virtual SENSOR_RESULT SetMeasurementTime(uint16_t pCfgData);
+    virtual SENSOR_RESULT ReadMeasurementTime(uint16_t *pCfgData);
+    virtual SENSOR_RESULT StartMeasurements();
+    virtual SENSOR_RESULT StopMeasurements();
+    virtual SENSOR_RESULT SetTIAGain(uint8_t pCfgData);
+    virtual SENSOR_RESULT ReadTIAGain(uint8_t *pCfgData);
+    virtual SENSOR_RESULT SetSensorBias(int16_t pCfgData);
+    virtual SENSOR_RESULT ReadSensorBias(int16_t *pCfgData);
+    virtual SENSOR_RESULT SetSensorSensitivity(uint32_t pCfgData);
+    virtual SENSOR_RESULT ReadSensorSensitivity(uint32_t *pCfgData);
+    virtual SENSOR_RESULT ConfigureTempComp(uint8_t pCfgData);
+    virtual SENSOR_RESULT ReadTempCompCfg(uint8_t *pCfgData);
+    virtual SENSOR_RESULT RunEISMeasurement();
+    virtual SENSOR_RESULT ReadEISResults(uint8_t *pSensData);
+    virtual SENSOR_RESULT ReadEISResultsFull(uint8_t *pSensData);
+
+    virtual SENSOR_RESULT Read200RCal(uint8_t *pSensData);
+    virtual SENSOR_RESULT RunPulseTest(uint8_t pulseAmplitude, uint8_t pulseDuration);
+    virtual SENSOR_RESULT ReadPulseTestResults(uint8_t *pSensData, uint8_t pulseAmplitude, uint8_t pulseDuration);
+    virtual SENSOR_RESULT SetRload(uint8_t pCfgData);
+    virtual SENSOR_RESULT ReadRload(uint8_t *pCfgData);
+    virtual SENSOR_RESULT ReadDataPPB(int32_t *pSensData);
+    virtual SENSOR_RESULT ReadDataBits(uint16_t *pSensData);
+
+    /*! I2C slave address defaults to static configuration but can be overriden at run-time.
+        If there are multiple ADT7420 devices on a system (sharing an I2C bus), the addresses
+        cannot map to the same static value.
+    */
+
+    uint8_t m_i2c_address;
+
+  private:
+
+    /*!
+        @brief   Initialize I2C.
+
+        @details This method is used to initialize I2C.
+    */
+    SENSOR_RESULT InitI2C();
+
+
+};
+}
+
+
+
+#endif /* ADI_M355_GAS_SENSOR_H_ */

--- a/Arduino Uno R3/examples/CN0429_example/adi_m355_gas_sensor_config.h
+++ b/Arduino Uno R3/examples/CN0429_example/adi_m355_gas_sensor_config.h
@@ -1,0 +1,15 @@
+/*
+   adi_m355_gas_sensor_config.h
+
+    Created on: Sep 4, 2017
+        Author: mraninec
+*/
+
+#ifndef ADI_M355_GAS_SENSOR_CONFIG_H_
+#define ADI_M355_GAS_SENSOR_CONFIG_H_
+
+/*! Default I2C address  (may be overriden) */
+#define ADI_CFG_I2C_DEFAULT_ADDR (0x4Cu)
+
+
+#endif /* ADI_M355_GAS_SENSOR_CONFIG_H_ */

--- a/Arduino Uno R3/examples/CN0429_example/adi_sensor.h
+++ b/Arduino Uno R3/examples/CN0429_example/adi_sensor.h
@@ -1,0 +1,236 @@
+/*!
+ *****************************************************************************
+  @file adi_sensor.h
+
+  @brief Sensor class definition.
+
+  @details
+  -----------------------------------------------------------------------------
+  Copyright (c) 2017 Analog Devices, Inc.
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+  - Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+  - Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  - Modified versions of the software must be conspicuously marked as such.
+  - This software is licensed solely and exclusively for use with processors
+    manufactured by or for Analog Devices, Inc.
+  - This software may not be combined or merged with other code in any manner
+    that would cause the software to become subject to terms and conditions
+    which differ from those listed here.
+  - Neither the name of Analog Devices, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+  - The use of this software may or may not infringe the patent rights of one
+    or more patent holders.  This license does not release you from the
+    requirement that you obtain separate licenses from these patent holders
+    to use this software.
+
+  THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-
+  INFRINGEMENT, TITLE, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL ANALOG DEVICES, INC. OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, DAMAGES ARISING OUT OF
+  CLAIMS OF INTELLECTUAL PROPERTY RIGHTS INFRINGEMENT; PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+#ifndef ADI_BASE_SENSOR_H
+#define ADI_BASE_SENSOR_H
+
+#include "adi_sensor_packet.h"
+#include "adi_sensor_errors.h"
+
+namespace adi_sensor_swpack
+{
+
+/*!
+   @class Sensor
+
+   @brief Generic interface for all sensors.
+
+ **/
+class Sensor
+{
+  public:
+
+    /**
+       @brief    Initalizes the sensor and configures it.
+
+       @return   SENSOR_RESULT
+
+       @details  Initializes the sensor, opens and configures the underlying peripheral.
+                 See sensor specific open member function for more details.
+    */
+    virtual SENSOR_RESULT   open() = 0;
+
+    /**
+       @brief    Starts sensor and enables the underlying device
+
+       @return   SENSOR_RESULT
+
+       @details  Start function's functionality varies from sensor to sensor. It enables
+                 the device so that data acquisition could start. See sensor specific
+                 start member function for more details.
+    */
+    virtual SENSOR_RESULT   start() = 0;
+
+    /**
+       @brief    Stops the sensor and disables the underlying device
+
+       @return   SENSOR_RESULT
+
+       @details  Stop function's functionality varies from sensor to sensor. It disables
+                 the device and stops any pending data transfers. See sensor specific
+                 stop member function for more details.
+    */
+    virtual SENSOR_RESULT   stop() = 0;
+
+    /**
+       @brief    Disables the sensor and closes underlying peripheral
+
+       @return   SENSOR_RESULT
+
+       @details  Close function disables the sensor and closes underlying peripheral.
+                 See sensor specific close member function for more details.
+    */
+    virtual SENSOR_RESULT   close() = 0;
+
+    /**
+       @brief    Function returns the sensor identifier.
+
+       @return   Returns the sensor ID.
+
+       @details  Sensor ID is used to uniquiely idenfify a sensor in system. This is
+                 used to pass information to the host application to identify the
+                 source of the sensor data. Sensor ID could be same across different
+                 types of the sensors but it should be unique with in a type.
+    */
+    uint32_t getID()
+    {
+      return m_sensor_id;
+    }
+
+    /**
+       @brief    Function returns the sensor type.
+
+       @return   Sensor type
+
+       @details  Returns the sensor type. See ADI_SENSOR_TYPE enumeration for supported
+                 sensor types.
+    */
+    ADI_SENSOR_TYPE getType()
+    {
+      return m_ADI_SENSOR_TYPE;
+    }
+
+    /**
+       @brief    Function returns the sensor version.
+
+       @return   Sensor version. A value of 0 is returned if sensor has no version
+                 information.
+
+       @details  Returns the sensor version. Sensor version contains the hardware
+                 version information. A sensor may or may not have this information.
+    */
+    uint32_t getVersion(void)
+    {
+      return 0;
+    }
+
+
+    /**
+       @brief    Function used to set the ID for the sensor.
+
+       @param    sensorID : Sensor ID to be set.
+
+       @return   none
+
+       @details  Sensor ID is used to identify a sensor in the system. Host applications
+                 uniquely identify a sensor based on its type and sensor id. Different
+                 sensor types can have the same id.
+    */
+    void setID(const uint32_t sensorID)
+    {
+      m_sensor_id = sensorID;
+    }
+
+    /**
+       @brief    Function used to set the type of the sensor
+
+       @param    sensorType : Sensor type to be used.
+
+       @return   none
+
+       @details  Sensor type is used to identify the type of the sensor.ADI_SENSOR_TYPE
+                 enumeration lists various supported sensor types. Host applications
+                 uniquely identify a sensor based on its type and sensor id. This
+                 function is typically implemented in the derived sensor classes.
+    */
+    void setType(const ADI_SENSOR_TYPE sensorType)
+    {
+      m_ADI_SENSOR_TYPE = sensorType;
+    }
+
+
+    /**
+       @brief    Function used to set the version of the sensor
+
+       @param    version : Sensor version to be used.
+
+       @return   none
+
+       @details  Sensor version holds the hardware version information of a sensor. This
+                 function is typically implemented in the derived sensor classes.
+    */
+    void setVersion(const uint32_t version)
+    {
+    }
+
+    /**
+       @brief    Returns the last hardware error
+
+       @return   Returns the hardware error.
+
+       @details  If any of the object member functions fails because of an hardware
+                 error this function has to be used to get the specific error.
+    */
+    uint32_t getLastHwError()
+    {
+      return 0;
+    }
+
+  protected:
+
+    /**
+       @brief    Sets the last hardware error
+
+       @param    lastError : Last hardware error
+
+       @return   none
+
+       @details  Sensor drivers use this function to store the hardware error.
+    */
+    void setLastHwError(const uint32_t lastError)
+    {
+      
+    }
+
+  private:
+    uint32_t    m_sensor_id;                     /*!< Sensor ID       */
+    ADI_SENSOR_TYPE m_ADI_SENSOR_TYPE;           /*!< Sensor Type     */
+};
+}
+
+#endif /* ADI_BASE_SENSOR_H */

--- a/Arduino Uno R3/examples/CN0429_example/adi_sensor_errors.h
+++ b/Arduino Uno R3/examples/CN0429_example/adi_sensor_errors.h
@@ -1,0 +1,125 @@
+/*!
+ *****************************************************************************
+  @file adi_sensor_errors.h
+
+  @brief Sensor error codes.
+
+  @details
+  -----------------------------------------------------------------------------
+  Copyright (c) 2017 Analog Devices, Inc.
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+  - Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+  - Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  - Modified versions of the software must be conspicuously marked as such.
+  - This software is licensed solely and exclusively for use with processors
+    manufactured by or for Analog Devices, Inc.
+  - This software may not be combined or merged with other code in any manner
+    that would cause the software to become subject to terms and conditions
+    which differ from those listed here.
+  - Neither the name of Analog Devices, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+  - The use of this software may or may not infringe the patent rights of one
+    or more patent holders.  This license does not release you from the
+    requirement that you obtain separate licenses from these patent holders
+    to use this software.
+
+  THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-
+  INFRINGEMENT, TITLE, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL ANALOG DEVICES, INC. OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, DAMAGES ARISING OUT OF
+  CLAIMS OF INTELLECTUAL PROPERTY RIGHTS INFRINGEMENT; PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+
+#ifndef ADI_SENSOR_ERRORS_H
+#define ADI_SENSOR_ERRORS_H
+
+
+#include <stdint.h>
+#include <assert.h>
+
+
+namespace adi_sensor_swpack
+{
+
+/*!
+    @addtogroup common_errors Error Handling
+    @ingroup common
+    @{
+
+    @brief    Result codes and error macros.
+
+    @details  Contains supported sensor errors and macros for packing and
+              unpacking these error codes. Also contains macros for printing
+              and asserting.
+*/
+
+/*! Given a #SENSOR_ERROR_TYPE type and a corresponding driver error code, format the error value. */
+#define SET_SENSOR_ERROR(type, error) (uint32_t)((error) | (type << 24ul))
+
+/*! Extract the #SENSOR_ERROR_TYPE from the #SENSOR_RESULT */
+#define GET_SENSOR_ERROR_TYPE(result) ((SENSOR_ERROR_TYPE) ((result & 0xFF000000ul) >> 24ul))
+
+/*! Extract the driver error code from the #SENSOR_RESULT - the type will be a ADI_XXX_RESULT enumeration */
+#define GET_DRIVER_ERROR_CODE(result) (result & 0x00FFFFFFul)
+
+/*! Sensor API result code */
+typedef uint32_t SENSOR_RESULT;
+
+/*! Sensor error types */
+typedef enum
+{
+  SENSOR_ERROR_NONE   = 0u,
+
+  /* Peripherals */
+  SENSOR_ERROR_DMA    = 1u,        /*!< DMA driver reported an error           */
+  SENSOR_ERROR_FLASH  = 2u,        /*!< Flash driver reported an error         */
+  SENSOR_ERROR_GPIO   = 3u,        /*!< GPIO driver reported an error          */
+  SENSOR_ERROR_I2C    = 4u,        /*!< I2C driver reported an error           */
+  SENSOR_ERROR_PWR    = 5u,        /*!< Power driver reported an error         */
+  SENSOR_ERROR_SPI    = 6u,        /*!< SPI driver reported an error           */
+  SENSOR_ERROR_SPORT  = 7u,        /*!< SPORT driver reported an error         */
+  SENSOR_ERROR_UART   = 8u,        /*!< UART driver reported an error          */
+
+  /* Sensors */
+  SENSOR_ERROR_ADC    = 9u,        /*!< ADC sensor reported an error           */
+  SENSOR_ERROR_AXL    = 10,        /*!< Accelerometer sensor reported an error */
+  SENSOR_ERROR_C02    = 11u,       /*!< C02 sensor reported an error           */
+  SENSOR_ERROR_GAS    = 12u,       /*!< Gas sensor reported an error           */
+  SENSOR_ERROR_LIGHT  = 13u,       /*!< Visual Light sensor reported an error  */
+  SENSOR_ERROR_PH     = 14u,       /*!< PH sensor reported an error            */
+  SENSOR_ERROR_TEMP   = 15u,       /*!< Temperature sensor reported an error   */
+
+} SENSOR_ERROR_TYPE;
+
+
+#ifdef ADI_DEBUG
+/*! Assert macro which maps to standard C assert in debug, nothing in release */
+#define ASSERT(x) assert(x)
+#else
+/*! Assert macro which maps to standard C assert in debug, nothing in release */
+#define ASSERT(x)
+#endif
+
+/*! Print the sensor error code by breaking it into the two parts using the macros defined above */
+#define PRINT_SENSOR_ERROR(func, result) func("Sensor Error = %X\tDriver Error = %X\r\n", (int) GET_SENSOR_ERROR_TYPE(result), (int) GET_DRIVER_ERROR_CODE(result))
+
+}
+
+#endif /* ADI_SENSOR_ERRORS_H */

--- a/Arduino Uno R3/examples/CN0429_example/adi_sensor_packet.h
+++ b/Arduino Uno R3/examples/CN0429_example/adi_sensor_packet.h
@@ -1,0 +1,249 @@
+/*!
+ *****************************************************************************
+  @file adi_sensor_packet.h
+
+  @brief Packet structure for sending data to the Android application.
+
+  @details
+  -----------------------------------------------------------------------------
+  Copyright (c) 2017 Analog Devices, Inc.
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+  - Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+  - Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  - Modified versions of the software must be conspicuously marked as such.
+  - This software is licensed solely and exclusively for use with processors
+    manufactured by or for Analog Devices, Inc.
+  - This software may not be combined or merged with other code in any manner
+    that would cause the software to become subject to terms and conditions
+    which differ from those listed here.
+  - Neither the name of Analog Devices, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+  - The use of this software may or may not infringe the patent rights of one
+    or more patent holders.  This license does not release you from the
+    requirement that you obtain separate licenses from these patent holders
+    to use this software.
+
+  THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-
+  INFRINGEMENT, TITLE, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL ANALOG DEVICES, INC. OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, DAMAGES ARISING OUT OF
+  CLAIMS OF INTELLECTUAL PROPERTY RIGHTS INFRINGEMENT; PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+
+*****************************************************************************/
+
+
+/**
+    @defgroup common Common
+*/
+
+
+#ifndef ADI_SENSOR_PACKET_H
+#define ADI_SENSOR_PACKET_H
+
+
+#include <stdint.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+namespace adi_sensor_swpack
+{
+
+#ifdef __cplusplus
+}
+#endif
+
+
+/*!
+    @addtogroup adi_packet Packet Definitions
+    @ingroup common
+    @{
+
+    @brief Packet definitions.
+    @details  Shared header file for common packet defintions
+*/
+
+
+/*! Takes in a #ADI_PACKET_TYPE and a user defined sensor id and formats it for a header */
+#define ADI_SET_HEADER(packet_type, id) ((id & 0x7Fu) | (packet_type << 7))
+
+/*! Maximum string size. This is: size of the data packet - header - 1 byte size = 20 - 6 - 1 = 13 */
+#define ADI_MAX_STRING_SIZE (13u)
+
+/*!
+   @enum ADI_PACKET_TYPE
+
+   @brief Packet type IDs
+
+   @note These correlate with the Android application. So any
+         changes here must be reflected in SharedDefines.java
+*/
+typedef enum
+{
+  /*!< Indicates that the current packet is a registration packet */
+  ADI_REGISTRATION_PACKET_TYPE     = 0x00u,
+  /*!< Indicates that the current packet is a data packet */
+  ADI_DATA_PACKET_TYPE             = 0x01u,
+} ADI_PACKET_TYPE;
+
+/*!
+   @enum ADI_SENSOR_TYPE
+
+   @brief Senor type IDs for the various types of sensors.
+
+   @note These correlate with the Android application. So any
+         changes here must be reflected in SharedDefines.java
+*/
+typedef enum
+{
+  ADI_GENERIC_TYPE         	    = 0x00u, /*!< Generic sensor type */
+  ADI_ACCELEROMETER_2G_TYPE     = 0x01u, /*!< Accelerometer (2G) type */
+  ADI_CO_TYPE                   = 0x02u, /*!< Carbon monoxide sensor type */
+  ADI_TEMPERATURE_TYPE          = 0x03u, /*!< Temperature sensor type */
+  ADI_VISIBLELIGHT_TYPE         = 0x04u, /*!< Visible light sensor type */
+  ADI_PRINTSTRING_TYPE          = 0x05u, /*!< Print string sensor type */
+  ADI_ACCELEROMETER_4G_TYPE     = 0x0Bu, /*!< Accelerometer (4G) type */
+  ADI_ACCELEROMETER_8G_TYPE     = 0x0Cu, /*!< Accelerometer (8G) type */
+} ADI_SENSOR_TYPE;
+
+/*!
+   @enum ADI_DATA_TYPE_KEY
+
+   @brief This is a key for the android app to determine how a data
+          field should be interpreted.
+
+   @note These correlate with the Android application. So any
+         changes here must be reflected in SharedDefines.java
+*/
+typedef enum
+{
+  ADI_BYTE_TYPE                 = 0x00u, /*!< 1 byte integer data bytes */
+  ADI_SHORT_TYPE                = 0x01u, /*!< 2 byte integer data bytes */
+  ADI_INT_TYPE                  = 0x02u, /*!< 4 byte integer data bytes */
+  ADI_LONG_TYPE                 = 0x03u, /*!< 8 byte integer data bytes */
+  ADI_FLOAT_TYPE                = 0x04u, /*!< 4 byte float data byte */
+  ADI_DOUBLE_TYPE               = 0x05u, /*!< 8 byte float data byte */
+  ADI_CHAR_TYPE                 = 0x06u, /*!< 1 byte char data byte */
+} ADI_DATA_TYPE_KEY;
+
+
+/*!
+    @struct ADI_STRING_DATA
+
+    @brief  data structure for the #ADI_PRINTSTRING_TYPE
+
+*/
+#pragma pack(push)
+#pragma pack(1)
+typedef struct
+{
+  uint8_t           nStringSize;                       /*!< Size of the string to send. Must not be larger than 13 bytes. */
+  uint8_t           aStringData[ADI_MAX_STRING_SIZE];  /*!< String to send.                                               */
+
+} ADI_STRING_DATA;
+#pragma pack(pop)
+
+/*!
+    @struct ADI_ACCELEROMETER_DATA
+
+    @brief  Data structure for the #ADI_ACCELEROMETER_2G_TYPE, #ADI_ACCELEROMETER_4G_TYPE
+            and #ADI_ACCELEROMETER_8G_TYPE.
+
+*/
+#pragma pack(push)
+#pragma pack(1)
+typedef struct
+{
+  uint8_t           aData_X[2];        /*!< Accelerometer X value */
+  uint8_t           aData_Y[2];        /*!< Accelerometer Y value */
+  uint8_t           aData_Z[2];        /*!< Accelerometer Z value */
+
+} ADI_ACCELEROMETER_DATA;
+#pragma pack(pop)
+
+/*!
+    @struct ADI_VISUAL_LIGHT_DATA
+
+    @brief  Data structure for the #ADI_VISIBLELIGHT_TYPE data type.
+
+*/
+#pragma pack(push)
+#pragma pack(1)
+typedef struct
+{
+  float           fData_Red;        /*!<  Red Photodiode in lux   */
+  float           fData_Green;      /*!<  Green Photodiode in lux */
+  float           fData_Blue;       /*!<  Blue Photodiode in lux  */
+
+} ADI_VISUAL_LIGHT_DATA;
+#pragma pack(pop)
+
+/*!
+    @struct ADI_DATA_PACKET
+
+    @brief  packet structure to send data to the Android application
+
+*/
+#pragma pack(push)
+#pragma pack(1)
+typedef struct
+{
+  uint8_t                     nPacketHeader;      /*!< Packet header has the first bit set to 0x1u to indicated this is a
+                                                        data packet. The rest of the 7 bits are used for the sensor id.
+                                                        This should be a unique identifier of the sensor instance.    */
+  ADI_SENSOR_TYPE             eSensorType;        /*!< Sensor type                                                  */
+  uint8_t                     aTimestamp[4];      /*!< Timestamp value                                              */
+  uint8_t                     aPayload[14];       /*!< Data payload. This varies based on the sensor sending data   */
+} ADI_DATA_PACKET;
+#pragma pack(pop)
+
+/*!
+    @struct ADI_REGISTRATION_PACKET
+
+    @brief  packet structure to send a registration packet to the Android application
+
+*/
+#pragma pack(push)
+#pragma pack(1)
+typedef struct
+{
+  uint8_t             nPacketHeader;          /*!< Packet header has the first bit set to 0x0u to indicated this is a
+                                                     registration packet. The rest of the 7 bits are used for the sensor id.
+                                                     This should be a unique identifier of the sensor instance.  */
+  ADI_SENSOR_TYPE     eSensorType;            /*!< Sensor type */
+  uint8_t             nNumDataTypes;          /*!< Number of data types  */
+  ADI_DATA_TYPE_KEY   aDataTypeKey[17];       /*!< For each data type (amount specified by nNumDataTypes), indicate
+                                                     how the Android application will interpret this data */
+} ADI_REGISTRATION_PACKET;
+#pragma pack(pop)
+
+/*! @} */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADI_SENSOR_PACKET_H */

--- a/Arduino Uno R3/examples/CN0429_example/cli.cpp
+++ b/Arduino Uno R3/examples/CN0429_example/cli.cpp
@@ -1,0 +1,880 @@
+/*
+   cli.c
+
+        Author: SHunt
+*/
+
+
+/***************************** Include Files **********************************/
+#include <Arduino.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include "cli.h"
+#include "ADuCM3029_demo_cn0428_cn0429.h"
+#include "Ringbuffer.h"
+
+/********************************* Definitions ********************************/
+
+
+
+/************************** Variable Definitions ******************************/
+/* Available commands */
+char *CmdCommands[] = {
+  "",
+  "help",
+  "defaultsensor",
+  "sensorsconnected",
+  "readconfigs",
+  "readtemp",
+  "readhum",
+  "setmeastime",
+  "startmeas",
+  "stopmeas",
+  "setsensitivity",
+  "readsensors",
+  "stopread",
+  "setupdaterate",
+  ""
+};
+
+/* Functions for available commands */
+cmdFunc CmdFun[] = {
+  DoNothing,
+  CmdHelp,
+  SetDefaultSns,
+  SnsConnected,
+  RdCfgs,
+  RdTemp,
+  RdHum,
+  CfgMeasTime,
+  StartMeas,
+  StopMeas,
+  CfgSens,
+  RdSensors,
+  StopRd,
+  NULL
+};
+
+
+
+/*Local Variables */
+uint8_t uiDefaultSite = 0;
+uint8_t uiDefaultAddress = 0;
+uint8_t uiPulseAmpl = 0;
+uint8_t uiPulseDur = 0;
+char strCmd[20] = "";
+
+uint8_t		cmdReceived = 0;			// flag indicating user command has been received (ENTER pressed)
+
+/****************************** Global functions ******************************/
+
+//#pragma GCC diagnostic push
+//#pragma GCC diagnostic ignored "-Wunused-parameter"
+
+/**
+   @brief Display info for <help> command
+
+   @param args - pointer to the arguments on the command line.
+
+   @return none
+**/
+void CmdHelp(uint8_t *args)
+{
+  Serial.println(F("help                           -Print commands"));
+  Serial.println(F("defaultsensor <site>           -Set default sensor site"));
+  Serial.println(F("                                  <site> = 1, 2, 3, 4"));
+  Serial.println(F("sensorsconnected               -Print which sensors are connected"));
+  Serial.println(F("readconfigs                    -Read sensor configurations"));
+  Serial.println(F("readtemp                       -Read temperature from on-board sensor"));
+  Serial.println(F("readhum                        -Read humidity from on-board sensor"));
+  Serial.println(F("                                  ADC performs avg of 10 samples at this interval"));
+  Serial.println(F("startmeas                      -Start ADC sampling at configured interval"));
+  Serial.println(F("stopmeas                       -Stop ADC sampling the sensor"));
+  Serial.println(F("setsensitivity <sens>          -Configure sensitivity"));
+  Serial.println(F("                                  <sens> = sensitivity in nA/ppm"));
+  Serial.println(F("readsensors                    -Read the ppb value of all sensors"));
+  Serial.println(F("stopread                       -Stop sensor data reading"));
+  Serial.println(F("\r\n"));
+}
+
+/**
+   @brief Finds the next command line argument
+
+   @param args - pointer to the arguments on the command line.
+
+   @return pointer to the next argument.
+
+**/
+uint8_t *FindArgv(uint8_t *args)
+{
+  uint8_t *p = args;
+  int     fl = 0;
+
+  while (*p != 0) {
+    if ((*p == _SPC))
+      fl = 1;
+    else if (fl)
+      break;
+    p++;
+  }
+
+  return p;
+}
+
+/**
+   @brief Separates a command line argument
+
+    @param dst - pointer to a buffer where the argument will be copied
+    @param args - pointer to the current position of the command line .
+
+   @return none
+
+**/
+void GetArgv(char *dst, uint8_t *args)
+{
+  uint8_t  *s = args;
+  char     *d = dst;
+
+  while (*s) {
+    if (*s == _SPC)
+      break;
+    *d++ = *s++;
+  }
+
+  *d = '\0';
+}
+
+/**
+   @brief Puts command for FSM to the ring buffer
+
+   @param cmd - pointer to the command
+
+   @return none
+**/
+void CmdToRB(const char *cmd)
+{
+  uint8_t cmdLen = strlen(cmd);
+  for (int i = 0; i < cmdLen; i++)
+  {
+    *RingBuf_Putvalue(&RX) = *cmd++;
+    RingBuf_Write_Increment(&RX);
+  }
+  Empty_Ring();
+}
+
+/**
+   @brief Command line process function
+
+   @return none
+**/
+void CmdProcess(void)
+{
+  cmdFunc   func;
+
+  Serial.print(cmdInString);
+  /* <ENTER> key was pressed */
+  /* Find needed function based on typed command */
+  func = FindCommand((char *)cmdInString);
+
+  /* Check if there is a valid command */
+  if (func) {
+    /* Call the desired function */
+    (*func)(&cmdInString[2]);
+    cmdInString[0] = '\0';
+    /* Check if there is no match for typed command */
+  } else if (strlen((const char *)cmdInString) != 0) {
+    /* Display a message for unknown command */
+    Serial.println(F("Unknown command!"));
+  }
+  /* Prepare for next <ENTER> */
+  // uart_cmd = UART_FALSE;
+  CmdPrompt();
+}
+
+/**
+   @brief Command line prompt. Caller must verify that only the enabled board can run this.
+
+   @return int - UART status: UART_SUCCESS or error status
+**/
+void CmdPrompt(void)
+{
+  static uint8_t count = 0;
+
+  /* Check first <ENTER> is pressed after reset */
+  if (count == 0) {
+    Serial.println(F("Welcome to CN0429!"));
+    Serial.println(F("Type <help> to see available commands..."));
+    count++;
+  }
+}
+
+/**
+   @brief Find available commands
+
+   @param cmd - command to search
+
+   @return cmdFunc - return the specific function for available command or NULL
+					 for invalid command
+**/
+cmdFunc FindCommand(char *cmd)
+{
+  cmdFunc func = NULL;
+  char *p = cmd;
+  int i = 0;
+  int f1 = 0;
+  int cmdlength = 0;
+
+  while (*p != 0)
+  {
+    if (*p == _SPC)
+      f1 = 1;
+    else if (!f1)
+      cmdlength++;
+    p++;
+  }
+
+  while (CmdFun[i] != NULL) {
+    if (strncmp(cmd, CmdCommands[i], cmdlength) == 0) {
+      func = CmdFun[i];
+      break;
+    }
+    i++;
+  }
+
+  return func;
+}
+
+void DoNothing()
+{
+  // nothing to do here
+  // this is to avoid help printing each time enter is pressed
+}
+
+/**
+   @brief Set sensor to use for single sensor commands
+
+   @param args - pointer to the arguments on the command line.
+   	   site: 1, 2, 3, or 4
+
+   @return none
+**/
+void SetDefaultSns(uint8_t *args)
+{
+  uint8_t  *p = args;
+  char     arg[17];
+
+  /* Check if this function gets an argument */
+  while (*(p = FindArgv(p)) != '\0') {
+    /* Save channel parameter */
+    GetArgv(arg, p);
+  }
+
+  /*DEFAULT CONFIGURATION*/
+  if (strncmp(arg, "1", 2) == 0)
+  {
+    uiDefaultSite = 1;
+    uiDefaultAddress = ADI_CFG_I2C_SENSOR1_ADDR;
+  }
+  else if (strncmp(arg, "2", 2) == 0)
+  {
+    uiDefaultSite = 2;
+    uiDefaultAddress = ADI_CFG_I2C_SENSOR2_ADDR;
+  }
+  else if (strncmp(arg, "3", 2) == 0)
+  {
+    uiDefaultSite = 3;
+    uiDefaultAddress = ADI_CFG_I2C_SENSOR3_ADDR;
+  }
+  else if (strncmp(arg, "4", 2) == 0)
+  {
+    uiDefaultSite = 4;
+    uiDefaultAddress = ADI_CFG_I2C_SENSOR4_ADDR;
+  }
+  else {
+    Serial.println(F("Invalid site"));
+  }
+  Serial.print(F("Selected site: ")); Serial.println(uiDefaultSite);
+}
+
+/**
+   @brief Print which sensors are connected
+
+   @param args - pointer to the arguments on the command line.
+
+   @return none
+**/
+void SnsConnected(uint8_t *args)
+{
+  memset(strCmd, '\0', sizeof(strCmd));
+  sprintf(strCmd, "PRESENCE_CHECK");
+  CmdToRB(strCmd);
+}
+
+/**
+   @brief Get configuration of sensors
+
+   @param args - pointer to the arguments on the command line.
+
+   @return none
+**/
+void RdCfgs(uint8_t *args)
+{
+  memset(strCmd, '\0', sizeof(strCmd));
+  sprintf(strCmd, "READ_CFGS");
+  CmdToRB(strCmd);
+}
+
+/**
+   @brief Read temperature from the daughter board's on-board T&RH sensor
+
+   @param args - pointer to the arguments on the command line.
+
+   @return none
+**/
+void RdTemp(uint8_t *args)
+{
+  memset(strCmd, '\0', sizeof(strCmd));
+  sprintf(strCmd, "READ_TEMP%c", uiDefaultAddress);
+  CmdToRB(strCmd);
+}
+
+/**
+   @brief Read humidity from the daughter board's on-board T&RH sensor
+
+   @param args - pointer to the arguments on the command line.
+
+   @return none
+**/
+void RdHum(uint8_t *args)
+{
+  memset(strCmd, '\0', sizeof(strCmd));
+  sprintf(strCmd, "READ_HUM%c", uiDefaultAddress);
+  CmdToRB(strCmd);
+}
+
+/**
+   @brief Set measurement time (ms)
+
+   @param args - pointer to the arguments on the command line.
+					time: [msec] 50 - 32000
+
+   @return none
+**/
+void CfgMeasTime(uint8_t *args)
+{
+  uint8_t  *p = args;
+  char     arg[17];
+  uint8_t  i;
+  uint8_t  digitcount = 0;
+  uint32_t value = 0;
+
+  /* Check if this function gets an argument */
+  while (*(p = FindArgv(p)) != '\0') {
+    /* Save channel parameter */
+    GetArgv(arg, p);
+  }
+
+  //Check if arg is numeric
+  for (i = 0; arg[i] != '\0'; i++)
+  {
+    // check for decimal digits
+    if (isdigit(arg[i]) != 0)
+      digitcount++;
+  }
+  if (digitcount == i) //All characters are numeric
+    value = strtol(arg, (char **)NULL, 10); //convert string to number
+  else
+    Serial.println(F("Invalid entry!"));
+
+  if (value > 32000 || value < 50)
+  {
+    value = 500;
+    Serial.println(F("Out of range! Set to default = 500 ms"));
+  }
+
+  memset(strCmd, '\0', sizeof(strCmd));
+  sprintf(strCmd, "CFG_MEASTIME%c%d", uiDefaultAddress, (uint16_t)value);
+  CmdToRB(strCmd);
+}
+
+/**
+   @brief Start ADC sampling the sensor
+
+   @param args - pointer to the arguments on the command line.
+
+   @return none
+**/
+void StartMeas(uint8_t *args)
+{
+  memset(strCmd, '\0', sizeof(strCmd));
+  sprintf(strCmd, "STARTMEAS%c", uiDefaultAddress);
+  CmdToRB(strCmd);
+}
+
+/**
+   @brief Stop ADC sampling the sensor
+
+   @param args - pointer to the arguments on the command line.
+
+   @return none
+**/
+void StopMeas(uint8_t *args)
+{
+  memset(strCmd, '\0', sizeof(strCmd));
+  sprintf(strCmd, "STOPMEAS%c", uiDefaultAddress);
+  CmdToRB(strCmd);
+}
+
+/**
+   @brief Program the TIA with the requested gain resistor
+
+   @param args - pointer to the arguments on the command line.
+					Rtia: from 0 to 26 equals 0R - 512k , see user guide for details
+
+   @return none
+**/
+void CfgRtia(uint8_t *args)
+{
+  uint8_t  *p = args;
+  char     arg[17];
+  uint8_t  i;
+  uint8_t  digitcount = 0;
+  uint32_t value = 0;
+
+  /* Check if this function gets an argument */
+  while (*(p = FindArgv(p)) != '\0') {
+    /* Save channel parameter */
+    GetArgv(arg, p);
+  }
+
+  //Check if arg is numeric
+  for (i = 0; arg[i] != '\0'; i++)
+  {
+    // check for decimal digits
+    if (isdigit(arg[i]) != 0)
+      digitcount++;
+  }
+  if (digitcount == i) //All characters are numeric
+    value = (uint8_t) strtol(arg, (char **)NULL, 10); //convert string to number
+  else
+    Serial.println(F("Invalid entry!"));
+
+  if (value > 26 || value < 0)
+  {
+    value = 1;
+    Serial.println(F("Out of range! Set to default = 200 ohm"));
+  }
+
+  memset(strCmd, '\0', sizeof(strCmd));
+  sprintf(strCmd, "CFG_RTIA%c%d", uiDefaultAddress, (uint16_t)value);
+  CmdToRB(strCmd);
+}
+
+/**
+   @brief Set sensor bias voltage
+
+   @param args - pointer to the arguments on the command line.
+					sensor bias: [mV] from -2200 to 2200
+
+   @return none
+**/
+void CfgVbias(uint8_t *args)
+{
+  uint8_t  *p = args;
+  char     arg[17];
+  uint8_t  i;
+  uint8_t  digitcount = 0;
+  int32_t value = 0;
+
+  /* Check if this function gets an argument */
+  while (*(p = FindArgv(p)) != '\0') {
+    /* Save channel parameter */
+    GetArgv(arg, p);
+  }
+
+  if (arg[0] == '-') digitcount++;
+  //Check if arg is numeric
+  for (i = 0; arg[i] != '\0'; i++)
+  {
+    // check for decimal digits
+    if (isdigit(arg[i]) != 0)
+      digitcount++;
+  }
+  if (digitcount == i) //All characters are numeric
+    value = (int32_t) strtol(arg, (char **)NULL, 10); //convert string to number
+  else
+    Serial.println(F("Invalid entry!"));
+
+  if (value > 2200 || value < -2200)
+  {
+    value = 0;
+    Serial.println(F("Out of range! Set to default = 0 mV"));
+  }
+
+  memset(strCmd, '\0', sizeof(strCmd));
+  sprintf(strCmd, "CFG_VBIAS%c%ld", uiDefaultAddress, (int32_t)value);
+  CmdToRB(strCmd);
+}
+
+/**
+   @brief Configure sensor sensitivity
+
+   @param args - pointer to the arguments on the command line.
+					sensitivity: [nA/ppm]
+
+   @return none
+**/
+void CfgSens(uint8_t *args)
+{
+  uint8_t  *p = args;
+  char     arg[17];
+  uint8_t  i;
+  uint8_t  digitcount = 0;
+  uint8_t  dotcount = 0;
+  float 	 value = 0;
+
+  /* Check if this function gets an argument */
+  while (*(p = FindArgv(p)) != '\0') {
+    /* Save channel parameter */
+    GetArgv(arg, p);
+  }
+
+  //Check if arg is numeric
+  for (i = 0; arg[i] != '\0'; i++)
+  {
+    // check for decimal digits
+    if (isdigit(arg[i]) != 0)
+      digitcount++;
+
+    if (arg[i] == '.')
+    {
+      digitcount++;
+      dotcount++;
+    }
+  }
+  if (digitcount == i) //All characters are numeric
+    value = strtod(arg, (char **)NULL); //convert string to number
+  else
+  {
+    Serial.println(F("Invalid entry!"));
+    return;
+  }
+  
+  if (dotcount > 1)
+  {
+    Serial.println(F("Invalid entry!"));
+    return;
+  }
+
+  if (value >= 32768 || value < 0)
+  {
+    Serial.println(F("Out of range!"));
+    return;
+  }
+
+  memset(strCmd, '\0', sizeof(strCmd));
+  sprintf(strCmd, "CFG_SENS%c%ld", uiDefaultAddress, (uint32_t)(value * 100));
+  CmdToRB(strCmd);
+}
+
+/**
+   @brief Configure temperature compensation of sensor reading
+
+   @param args - pointer to the arguments on the command line.
+					temperature compensation: enabled/disabled
+
+   @return none
+**/
+void CfgTempComp(uint8_t *args)
+{
+  uint8_t  *p = args;
+  char     arg[17];
+
+  /* Check if this function gets an argument */
+  while (*(p = FindArgv(p)) != '\0') {
+    /* Save channel parameter */
+    GetArgv(arg, p);
+  }
+
+  if ((arg[0] == '0' || arg[0] == '1') && arg[1] == '\0')
+  {
+    memset(strCmd, '\0', sizeof(strCmd));
+    sprintf(strCmd, "CFG_TEMPCOMP%c%c", uiDefaultAddress, arg[0]);
+    CmdToRB(strCmd);
+
+  }
+  else
+    Serial.println(F("Invalid entry! 0 or 1 allowed"));
+}
+
+/**
+   @brief Start electrochemical impedance spectroscopy test
+
+   @param args - pointer to the arguments on the command line.
+
+   @return none
+**/
+void RunEIS(uint8_t *args)
+{
+  memset(strCmd, '\0', sizeof(strCmd));
+  sprintf(strCmd, "RUN_EIS%c", uiDefaultAddress);
+  CmdToRB(strCmd);
+}
+
+/**
+   @brief Read electrochemical impedance spectroscopy results
+
+   @param args - pointer to the arguments on the command line.
+
+   @return none
+**/
+void RdEIS(uint8_t *args)
+{
+  memset(strCmd, '\0', sizeof(strCmd));
+  sprintf(strCmd, "READ_EIS%c%s", uiDefaultAddress, _EOS);
+  CmdToRB(strCmd);
+}
+
+/**
+   @brief Read electrochemical impedance spectroscopy FULL results
+
+   @param args - pointer to the arguments on the command line.
+
+   @return none
+**/
+void RdEISfull(uint8_t *args)
+{
+  memset(strCmd, '\0', sizeof(strCmd));
+  sprintf(strCmd, "READ_FULL_EIS%c%s", uiDefaultAddress, _EOS);
+  CmdToRB(strCmd);
+}
+
+/**
+   @brief Read the value of the 200R calibration resistor
+
+   @param args - pointer to the arguments on the command line.
+
+   @return none
+**/
+void RdRcal(uint8_t *args)
+{
+  memset(strCmd, '\0', sizeof(strCmd));
+  sprintf(strCmd, "READ_RCAL%c%s", uiDefaultAddress, _EOS);
+  CmdToRB(strCmd);
+}
+
+/**
+   @brief Start chronoamperometry pulse test
+
+   @param args - pointer to the arguments on the command line.
+
+   @return none
+**/
+void RunPulse(uint8_t *args)
+{
+  if (uiPulseAmpl != 0 && uiPulseDur != 0)
+  {
+    memset(strCmd, '\0', sizeof(strCmd));
+    sprintf(strCmd, "RUN_PULSE%c%c%c", uiDefaultAddress, uiPulseAmpl, uiPulseDur);
+    CmdToRB(strCmd);
+  }
+  else
+  {
+    Serial.println(F("Pulse and/or Duration not set!"));
+  }
+}
+
+/**
+   @brief Read results of chronoamperometry pulse test
+
+   @param args - pointer to the arguments on the command line.
+
+   @return none
+**/
+void ReadPulse(uint8_t *args)
+{
+  memset(strCmd, '\0', sizeof(strCmd));
+  sprintf(strCmd, "PULSE_RESULT%c%c%c", uiDefaultAddress, uiPulseAmpl, uiPulseDur);
+  CmdToRB(strCmd);
+}
+
+/**
+   @brief Set step amplitude for pulse test
+
+   @param args - pointer to the arguments on the command line.
+   	   amplitude: [mV] - Amplitude of the pulse in mV (typically 1mV)
+
+   @return none
+**/
+void SetPulseAmpl(uint8_t *args)
+{
+  uint8_t  *p = args;
+  char     arg[17];
+  uint8_t  i;
+  uint8_t  digitcount = 0;
+
+  /* Check if this function gets an argument */
+  while (*(p = FindArgv(p)) != '\0') {
+    /* Save channel parameter */
+    GetArgv(arg, p);
+  }
+
+  //Check if arg is numeric
+  for (i = 0; arg[i] != '\0'; i++)
+  {
+    // check for decimal digits
+    if (isdigit(arg[i]) != 0)
+      digitcount++;
+  }
+  if (digitcount == i) //All characters are numeric
+    uiPulseAmpl = (uint8_t) strtol(arg, (char **)NULL, 10); //convert string to number
+  else
+  {
+    Serial.println(F("Invalid entry!"));
+    return;
+  }
+
+  if (uiPulseAmpl >= 3 || uiPulseAmpl < 1)
+  {
+    uiPulseAmpl = 1;
+    Serial.println(F("Out of range! Set to default = 1 mV"));
+    return;
+  }
+
+  memset(strCmd, '\0', sizeof(strCmd));
+  Serial.print(F("Pulse amplitude set to "));
+  Serial.print(uiPulseAmpl, DEC); Serial.println(F(" mV"));
+}
+
+/**
+   @brief Set duration for CAPA test
+
+   @param args - pointer to the arguments on the command line.
+   	   duration: [milliseconds] - Duration of the pulse (keep <200 ms)
+
+   @return none
+**/
+void SetPulseDuration(uint8_t *args)
+{
+  uint8_t  *p = args;
+  char     arg[17];
+  uint8_t  i;
+  uint8_t  digitcount = 0;
+
+  /* Check if this function gets an argument */
+  while (*(p = FindArgv(p)) != '\0') {
+    /* Save channel parameter */
+    GetArgv(arg, p);
+  }
+
+  //Check if arg is numeric
+  for (i = 0; arg[i] != '\0'; i++)
+  {
+    // check for decimal digits
+    if (isdigit(arg[i]) != 0)
+      digitcount++;
+  }
+  if (digitcount == i) //All characters are numeric
+    uiPulseDur = (uint8_t) strtol(arg, (char **)NULL, 10); //convert string to number
+  else
+    Serial.println(F("Invalid entry!"));
+
+  if (uiPulseDur > 200 || uiPulseDur < 1)
+  {
+    uiPulseDur = 50;
+    Serial.println(F("Out of range! Set to default = 50 msec"));
+  }
+
+  memset(strCmd, '\0', sizeof(strCmd));
+  Serial.print(F("Pulse duration set to "));
+  Serial.print(uiPulseDur, DEC); Serial.println(F(" msec"));
+}
+
+/**
+   @brief Select sensor load resistor
+
+   @param args - pointer to the arguments on the command line.
+					Rtia: from 0 to 7 equals 0R - 3k6 , see user guide for details
+
+   @return none
+**/
+void CfgRload(uint8_t *args)
+{
+  uint8_t  *p = args;
+  char     arg[17];
+  uint8_t  i;
+  uint8_t  digitcount = 0;
+  uint32_t value = 0;
+
+  /* Check if this function gets an argument */
+  while (*(p = FindArgv(p)) != '\0') {
+    /* Save channel parameter */
+    GetArgv(arg, p);
+  }
+
+  //Check if arg is numeric
+  for (i = 0; arg[i] != '\0'; i++)
+  {
+    // check for decimal digits
+    if (isdigit(arg[i]) != 0)
+      digitcount++;
+  }
+  if (digitcount == i) //All characters are numeric
+    value = (uint8_t) strtol(arg, (char **)NULL, 10); //convert string to number
+  else
+    Serial.println(F("Invalid entry!"));
+
+  if (value > 7 || value < 0)
+  {
+    value = 1;
+    Serial.println(F("Out of range! Set to default = 10 ohm"));
+  }
+
+  memset(strCmd, '\0', sizeof(strCmd));
+  Serial.print(F("CFG_RLOAD"));
+  Serial.print(uiDefaultAddress); Serial.println((uint16_t)value, DEC);
+  CmdToRB(strCmd);
+}
+
+/**
+   @brief Read the value of the configured load resistor
+
+   @param args - pointer to the arguments on the command line.
+
+   @return none
+**/
+void RdRload(uint8_t *args)
+{
+  memset(strCmd, '\0', sizeof(strCmd));
+  sprintf(strCmd, "READ_RLOAD%c", uiDefaultAddress, _EOS);
+  CmdToRB(strCmd);
+}
+
+/**
+   @brief Read ppb value of all sensors
+
+   @param args - pointer to the arguments on the command line.
+
+   @return none
+**/
+void RdSensors(uint8_t *args)
+{
+  memset(strCmd, '\0', sizeof(strCmd));
+  sprintf(strCmd, "READALLSENSORS");
+  CmdToRB(strCmd);
+}
+
+/**
+   @brief Stop reading sensor data
+
+   @param args - pointer to the arguments on the command line.
+
+   @return none
+**/
+void StopRd(uint8_t *args)
+{
+  FSM_State = COMMAND;
+  Serial.println(F("Data reading interrupted!"));
+}

--- a/Arduino Uno R3/examples/CN0429_example/cli.h
+++ b/Arduino Uno R3/examples/CN0429_example/cli.h
@@ -1,0 +1,56 @@
+/*
+ * cli.h
+ *
+ *      Author: SHunt
+ */
+
+#ifndef CLI_H_
+#define CLI_H_
+
+
+/******************************  Variables  **********************************/
+extern uint8_t		cmdReceived;
+
+/****************************** Internal types ********************************/
+
+typedef  void (*cmdFunc)(uint8_t *);
+
+/*************************** Functions prototypes *****************************/
+void DoNothing();
+void CmdHelp(uint8_t *args);
+uint8_t *FindArgv(uint8_t *args);
+void GetArgv(char *dst, uint8_t *args);
+void CmdProcess(void);
+void CmdPrompt(void);
+cmdFunc FindCommand(char *cmd);
+void SetDefaultSns(uint8_t *args);
+void SnsConnected(uint8_t *args);
+void RdCfgs(uint8_t *args);
+void RdTemp(uint8_t *args);
+void RdHum(uint8_t *args);
+void CfgMeasTime(uint8_t *args);
+void StartMeas(uint8_t *args);
+void StopMeas(uint8_t *args);
+void CfgRtia(uint8_t *args);
+void CfgRload(uint8_t *args);
+void CfgVbias(uint8_t *args);
+void CfgSens(uint8_t *args);
+void CfgTempComp(uint8_t *args);
+void RunEIS(uint8_t *args);
+void RdEIS(uint8_t *args);
+void RdEISfull(uint8_t *args);
+void RdRcal(uint8_t *args);
+void RunPulse(uint8_t *args);
+void ReadPulse(uint8_t *args);
+void SetPulseAmpl(uint8_t *args);
+void SetPulseDuration(uint8_t *args);
+void RdSensors(uint8_t *args);
+void StopRd(uint8_t *args);
+void CfgUpdateRate(uint8_t *args);
+
+
+
+
+
+
+#endif /* CLI_H_ */


### PR DESCRIPTION
The CN0429_example is a demo using the EVAL-CN0428-EBZ and the EVAL-M355-ARDZ-INT boards as a solution for detecting toxic gases. By utilizing built-in diagnostics features (such as impedance spectroscopy or bias voltage pulsing and ramping) it is possible to inspect sensor health, compensate for accuracy drift due to aging or temperature, and estimate the remaining lifetime of the sensor.